### PR TITLE
Cross compile go-binaries as release artifacts

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,44 @@
+
+
+# Name:        release.yaml
+# Author:      Mathew Fleisch <mathew.fleisch@gmail.com>
+# Description: This action will cross-compile and save go binaires as release artifacts 
+name: Release gcredstash
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: Release gcredstash
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout gcredstash source
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - 
+        name: Install stuff with asdf
+        uses: asdf-vm/actions/install@v1
+        with:
+          tool_versions: |
+            golang 1.19.4
+      -
+        name: Set tag environment variable
+        run: |
+          echo "RELEASE_VERSION=$(make version)" >> $GITHUB_ENV
+      -
+        name: Build go-binaries
+        run: |
+          make cross-compile
+          echo "Go-Binaries created: $(ls bin -alF)"
+      -
+        name: Cut Github Release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GIT_TOKEN }}
+          allowUpdates: true
+          artifacts: "bin/*"
+          tag: gcredstash-${{ env.RELEASE_VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /*.test
-/gcredstash
+/gcredstash*
 /gcredstash.exe
+bin
 *.gz
 *.zip
 /debian/gcredstash.debhelper.log


### PR DESCRIPTION
You will need to set up a `GIT_TOKEN` with write permissions as a github secret in your repository settings for this action to work.

https://github.com/mathew-fleisch/gcredstash/releases/tag/gcredstash-v0.3.5-71d53ed

```text
Run make cross-compile
rm -rf bin
rm -f gcredstash{,.exe} *.gz *.zip
rm -f pkg/*
rm -f debian/gcredstash.debhelper.log
rm -f debian/gcredstash.substvars
rm -f debian/files
rm -rf debian/gcredstash/
mkdir -p bin
GOOS=linux   GOARCH=amd64 go build -a -ldflags "-w -s" -tags netgo -installsuffix netgo -o bin/gcredstash-linux-amd64
go: downloading github.com/aws/aws-sdk-go v1.34.23
go: downloading github.com/mitchellh/cli v1.1.1
go: downloading github.com/mattn/go-shellwords v1.0.10
go: downloading github.com/ryanuber/go-glob v1.0.0
go: downloading github.com/jmespath/go-jmespath v0.3.0
go: downloading github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310
go: downloading github.com/bgentry/speakeasy v0.1.0
go: downloading github.com/fatih/color v1.7.0
go: downloading github.com/mattn/go-isatty v0.0.3
go: downloading github.com/posener/complete v1.1.1
go: downloading github.com/mattn/go-colorable v0.0.[9](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:10)
go: downloading github.com/hashicorp/go-multierror v1.0.0
go: downloading github.com/hashicorp/errwrap v1.0.0
GOOS=linux   GOARCH=arm64 go build -a -ldflags "-w -s" -tags netgo -installsuffix netgo -o bin/gcredstash-linux-arm64
GOOS=darwin  GOARCH=amd64 go build -a -ldflags "-w -s" -tags netgo -installsuffix netgo -o bin/gcredstash-darwin-amd64
GOOS=darwin  GOARCH=arm64 go build -a -ldflags "-w -s" -tags netgo -installsuffix netgo -o bin/gcredstash-darwin-arm64
Go-Binaries created: total 44016
drwxr-xr-x  2 runner docker     4096 Feb 20 17:05 ./
drwxr-xr-x [10](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:11) runner docker     4096 Feb 20 17:04 ../
-rwxr-xr-x  1 runner docker [11](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:12)903520 Feb 20 17:05 gcredstash-darwin-amd64*
-rwxr-xr-x  1 runner docker 1160[12](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:13)66 Feb 20 [17](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:18):05 gcredstash-darwin-arm64*
-rwxr-xr-x  1 runner docker 10997760 Feb [20](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:21) 17:04 gcredstash-linux-amd64*
-rwxr-xr-x  1 runner docker 10551[29](https://github.com/mathew-fleisch/gcredstash/actions/runs/4225625012/jobs/7338141064#step:5:30)6 Feb 20 17:05 gcredstash-linux-arm64*
```