### PR TITLE
Automatically regenerate mocks when dependabot opens a PR

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,30 @@
+---
+name: Regenerate mocks
+
+on:
+  - pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+
+      - run: |
+          make mock
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add internal/mockaws
+          git commit -m "Update mocks"
+          git push


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new GitHub Actions workflow that automatically regenerates mocks whenever Dependabot opens a pull request. This ensures that the mocks are always up-to-date with the latest dependencies.

- **CI**:
    - Added a GitHub Actions workflow to automatically regenerate mocks when Dependabot opens a pull request.

<!-- Generated by sourcery-ai[bot]: end summary -->