### PR TITLE
Lean on goreleaser for docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
   - push
   - pull_request
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version-file: go.mod
+        check-latest: true
+        cache: true
 
     - name: Lint
       uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
 
     permissions:
       contents: write
+      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +34,19 @@ jobs:
           check-latest: true
           cache: true
 
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -42,34 +56,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP }}
-
-  build-and-push-image:
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          REGISTRY: ${{ env.REGISTRY }}
+          IMAGE: ${{ env.IMAGE_NAME }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -78,6 +78,13 @@ nfpms:
     formats:
       - rpm
 
+dockers:
+  - image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:{{ .Tag }}"
+    skip_push: auto
+    use: buildx
+    dockerfile: Dockerfile
+
 checksum:
   algorithm: sha256
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-FROM golang:1.18 AS builder
-
-ENV GOPATH /go
-ENV APPPATH /repo
-COPY . /repo
-RUN cd /repo && make
-
 FROM alpine:latest
-COPY --from=builder /repo/gcredstash /gcredstash
+COPY gcredstash .
 ENTRYPOINT ["/gcredstash"]


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the GitHub Actions workflows to streamline the build and release process by leveraging GoReleaser for Docker image builds and pushes. It also includes updates to action versions and permissions configurations.

- **Enhancements**:
    - Updated GitHub Actions workflows to use the latest versions of actions/checkout, actions/setup-go, docker/login-action, and docker/metadata-action.
    - Configured GoReleaser to handle Docker image builds and pushes, consolidating the build and release process.
- **CI**:
    - Added permissions for contents and pull-requests in the build workflow.
    - Updated the release workflow to grant write permissions to packages.

<!-- Generated by sourcery-ai[bot]: end summary -->