### PR TITLE
Add latest tag to future images

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -81,6 +81,7 @@ nfpms:
 dockers:
   - image_templates:
       - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:{{ .Tag }}"
+      - "{{ .Env.REGISTRY }}/{{ .Env.IMAGE }}:latest"
     skip_push: auto
     use: buildx
     dockerfile: Dockerfile


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the .goreleaser.yaml configuration to include a 'latest' tag for Docker images, ensuring that future images are tagged with 'latest' in addition to their version-specific tags.

- **Deployment**:
    - Added 'latest' tag to Docker image templates in .goreleaser.yaml to ensure future images are tagged with 'latest'.

<!-- Generated by sourcery-ai[bot]: end summary -->