### PR TITLE
Fix misspelling

### DIFF
--- a/internal/command/delete.go
+++ b/internal/command/delete.go
@@ -23,7 +23,7 @@ func init() {
 	}
 
 	flag := cmd.Flags()
-	flag.StringVarP(&version, "version", "v", "", "delete a specfic version of the credential")
+	flag.StringVarP(&version, "version", "v", "", "delete a specific version of the credential")
 
 	Root.AddCommand(cmd)
 }


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a misspelling in the flag description of the delete command, improving the clarity of the user-facing message.

- **Bug Fixes**:
    - Corrected a misspelling in the flag description from 'specfic' to 'specific' in the delete command.

<!-- Generated by sourcery-ai[bot]: end summary -->