### PR TITLE
Switch to stefanzweifel/git-auto-commit-action

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -11,8 +11,11 @@ jobs:
   build:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -23,10 +26,7 @@ jobs:
 
       - run: |
           make mock
-          if test "$(git status --porcelain | wc -l)" -gt 0; then
-              git config user.name github-actions
-              git config user.email github-actions@github.com
-              git add internal/mockaws
-              git commit -m "Update mocks"
-              git push
-          fi
+
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "Update mocks"


### PR DESCRIPTION
Better than me trying to maintain this.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the dependabot workflow to use the stefanzweifel/git-auto-commit-action for automatically committing and pushing changes, replacing the previous manual steps.

- **CI**:
    - Replaced manual git commit and push steps with stefanzweifel/git-auto-commit-action in the dependabot workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->