### PR TITLE
s/cannot/can't/g for consistency

### DIFF
--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -39,7 +39,7 @@ func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 		}
 		result, err := internal.JSONMarshal(creds)
 		if err != nil {
-			return fmt.Errorf("cannot marshal credential: %w", err)
+			return fmt.Errorf("can't marshal credential: %w", err)
 		}
 		cmd.Print(string(result))
 	} else {

--- a/internal/command/getall.go
+++ b/internal/command/getall.go
@@ -28,7 +28,7 @@ func getAllImpl(cmd *cobra.Command, args []string, driver *internal.Driver) erro
 
 	jsonString, err := internal.JSONMarshal(creds)
 	if err != nil {
-		return fmt.Errorf("cannot marshal credentials: %w", err)
+		return fmt.Errorf("can't marshal credentials: %w", err)
 	}
 
 	cmd.Print(string(jsonString))

--- a/internal/command/put.go
+++ b/internal/command/put.go
@@ -26,7 +26,7 @@ func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	if autoVersion {
 		latestVersion, err := driver.GetHighestVersion(credential, table)
 		if err != nil {
-			return fmt.Errorf("cannot fetch highest version: %w", err)
+			return fmt.Errorf("can't fetch highest version: %w", err)
 		}
 		latestVersion++
 		version = internal.VersionNumToStr(latestVersion)
@@ -35,7 +35,7 @@ func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	}
 
 	if err := driver.PutSecret(credential, value, version, key, table, context); err != nil {
-		return fmt.Errorf("cannot store secret: %w", err)
+		return fmt.Errorf("can't store secret: %w", err)
 	}
 
 	cmd.Printf("%v has been stored\n", credential)

--- a/internal/command/template.go
+++ b/internal/command/template.go
@@ -25,23 +25,23 @@ func templateImpl(cmd *cobra.Command, args []string, driver *internal.Driver) er
 		var err error
 		content, err = internal.ReadFile(tmplFile)
 		if err != nil {
-			return fmt.Errorf("cannot read %q: %w", tmplFile, err)
+			return fmt.Errorf("can't read %q: %w", tmplFile, err)
 		}
 	}
 
 	tmpl, err := makeTemplate(driver, table).Parse(content)
 	if err != nil {
-		return fmt.Errorf("cannot parse %q template: %w", tmplFile, err)
+		return fmt.Errorf("can't parse %q template: %w", tmplFile, err)
 	}
 
 	buf := &bytes.Buffer{}
 	if err = tmpl.Execute(buf, nil); err != nil {
-		return fmt.Errorf("cannot execute %q template: %w", tmplFile, err)
+		return fmt.Errorf("can't execute %q template: %w", tmplFile, err)
 	}
 
 	if inplace {
 		if err := os.WriteFile(tmplFile, buf.Bytes(), 0o644); err != nil { //nolint:gosec
-			return fmt.Errorf("cannot write to %q: %w", tmplFile, err)
+			return fmt.Errorf("can't write to %q: %w", tmplFile, err)
 		}
 	}
 

--- a/internal/driver.go
+++ b/internal/driver.go
@@ -30,7 +30,7 @@ type Driver struct {
 func NewDriver() (*Driver, error) {
 	awsSession, err := session.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("cannot create session: %w", err)
+		return nil, fmt.Errorf("can't create session: %w", err)
 	}
 	driver := &Driver{
 		Ddb: dynamodb.New(awsSession),


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Standardize error message phrasing by replacing 'cannot' with 'can't' across multiple files for consistency.

Enhancements:
- Standardize error messages by replacing 'cannot' with 'can't' for consistency across the codebase.

<!-- Generated by sourcery-ai[bot]: end summary -->