### PR TITLE
Update mocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,6 @@ tests:
 
 .PHONY: mocks
 mocks:
-	go install go.uber.org/mock/mockgen@v0.4.0
+	go install go.uber.org/mock/mockgen@v0.5.2
 	mockgen -package mockaws -destination internal/mockaws/dynamodbmock.go github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface DynamoDBAPI
 	mockgen -package mockaws -destination internal/mockaws/kmsmock.go github.com/aws/aws-sdk-go/service/kms/kmsiface KMSAPI

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,15 @@
 module github.com/kgaughan/gcredstash
 
-go 1.22
+go 1.23
 
-toolchain go1.23.2
+toolchain go1.24.2
 
 require (
 	github.com/aws/aws-sdk-go v1.55.7
 	github.com/mattn/go-shellwords v1.0.12
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/spf13/cobra v1.9.1
-	go.uber.org/mock v0.5.1
+	go.uber.org/mock v0.5.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wx
 github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
 github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-go.uber.org/mock v0.5.1 h1:ASgazW/qBmR+A32MYFDB6E2POoTgOwT509VP0CT/fjs=
-go.uber.org/mock v0.5.1/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
+go.uber.org/mock v0.5.2 h1:LbtPTcP8A5k9WPXj54PPPbjcI4Y6lhyOZXn+VS7wNko=
+go.uber.org/mock v0.5.2/go.mod h1:wLlUxC2vVTPTaE3UD51E0BGOAElKrILxhVSDYQLld5o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/internal/mockaws/dynamodbmock.go
+++ b/internal/mockaws/dynamodbmock.go
@@ -10,9 +10,9 @@
 package mockaws
 
 import (
-	context "context"
 	reflect "reflect"
 
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	dynamodb "github.com/aws/aws-sdk-go/service/dynamodb"
 	gomock "go.uber.org/mock/gomock"
@@ -22,6 +22,7 @@ import (
 type MockDynamoDBAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockDynamoDBAPIMockRecorder
+	isgomock struct{}
 }
 
 // MockDynamoDBAPIMockRecorder is the mock recorder for MockDynamoDBAPI.
@@ -72,7 +73,7 @@ func (mr *MockDynamoDBAPIMockRecorder) BatchExecuteStatementRequest(arg0 any) *g
 }
 
 // BatchExecuteStatementWithContext mocks base method.
-func (m *MockDynamoDBAPI) BatchExecuteStatementWithContext(arg0 context.Context, arg1 *dynamodb.BatchExecuteStatementInput, arg2 ...request.Option) (*dynamodb.BatchExecuteStatementOutput, error) {
+func (m *MockDynamoDBAPI) BatchExecuteStatementWithContext(arg0 aws.Context, arg1 *dynamodb.BatchExecuteStatementInput, arg2 ...request.Option) (*dynamodb.BatchExecuteStatementOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -121,7 +122,7 @@ func (mr *MockDynamoDBAPIMockRecorder) BatchGetItemPages(arg0, arg1 any) *gomock
 }
 
 // BatchGetItemPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) BatchGetItemPagesWithContext(arg0 context.Context, arg1 *dynamodb.BatchGetItemInput, arg2 func(*dynamodb.BatchGetItemOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) BatchGetItemPagesWithContext(arg0 aws.Context, arg1 *dynamodb.BatchGetItemInput, arg2 func(*dynamodb.BatchGetItemOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -155,7 +156,7 @@ func (mr *MockDynamoDBAPIMockRecorder) BatchGetItemRequest(arg0 any) *gomock.Cal
 }
 
 // BatchGetItemWithContext mocks base method.
-func (m *MockDynamoDBAPI) BatchGetItemWithContext(arg0 context.Context, arg1 *dynamodb.BatchGetItemInput, arg2 ...request.Option) (*dynamodb.BatchGetItemOutput, error) {
+func (m *MockDynamoDBAPI) BatchGetItemWithContext(arg0 aws.Context, arg1 *dynamodb.BatchGetItemInput, arg2 ...request.Option) (*dynamodb.BatchGetItemOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -205,7 +206,7 @@ func (mr *MockDynamoDBAPIMockRecorder) BatchWriteItemRequest(arg0 any) *gomock.C
 }
 
 // BatchWriteItemWithContext mocks base method.
-func (m *MockDynamoDBAPI) BatchWriteItemWithContext(arg0 context.Context, arg1 *dynamodb.BatchWriteItemInput, arg2 ...request.Option) (*dynamodb.BatchWriteItemOutput, error) {
+func (m *MockDynamoDBAPI) BatchWriteItemWithContext(arg0 aws.Context, arg1 *dynamodb.BatchWriteItemInput, arg2 ...request.Option) (*dynamodb.BatchWriteItemOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -255,7 +256,7 @@ func (mr *MockDynamoDBAPIMockRecorder) CreateBackupRequest(arg0 any) *gomock.Cal
 }
 
 // CreateBackupWithContext mocks base method.
-func (m *MockDynamoDBAPI) CreateBackupWithContext(arg0 context.Context, arg1 *dynamodb.CreateBackupInput, arg2 ...request.Option) (*dynamodb.CreateBackupOutput, error) {
+func (m *MockDynamoDBAPI) CreateBackupWithContext(arg0 aws.Context, arg1 *dynamodb.CreateBackupInput, arg2 ...request.Option) (*dynamodb.CreateBackupOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -305,7 +306,7 @@ func (mr *MockDynamoDBAPIMockRecorder) CreateGlobalTableRequest(arg0 any) *gomoc
 }
 
 // CreateGlobalTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) CreateGlobalTableWithContext(arg0 context.Context, arg1 *dynamodb.CreateGlobalTableInput, arg2 ...request.Option) (*dynamodb.CreateGlobalTableOutput, error) {
+func (m *MockDynamoDBAPI) CreateGlobalTableWithContext(arg0 aws.Context, arg1 *dynamodb.CreateGlobalTableInput, arg2 ...request.Option) (*dynamodb.CreateGlobalTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -355,7 +356,7 @@ func (mr *MockDynamoDBAPIMockRecorder) CreateTableRequest(arg0 any) *gomock.Call
 }
 
 // CreateTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) CreateTableWithContext(arg0 context.Context, arg1 *dynamodb.CreateTableInput, arg2 ...request.Option) (*dynamodb.CreateTableOutput, error) {
+func (m *MockDynamoDBAPI) CreateTableWithContext(arg0 aws.Context, arg1 *dynamodb.CreateTableInput, arg2 ...request.Option) (*dynamodb.CreateTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -405,7 +406,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DeleteBackupRequest(arg0 any) *gomock.Cal
 }
 
 // DeleteBackupWithContext mocks base method.
-func (m *MockDynamoDBAPI) DeleteBackupWithContext(arg0 context.Context, arg1 *dynamodb.DeleteBackupInput, arg2 ...request.Option) (*dynamodb.DeleteBackupOutput, error) {
+func (m *MockDynamoDBAPI) DeleteBackupWithContext(arg0 aws.Context, arg1 *dynamodb.DeleteBackupInput, arg2 ...request.Option) (*dynamodb.DeleteBackupOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -455,7 +456,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DeleteItemRequest(arg0 any) *gomock.Call 
 }
 
 // DeleteItemWithContext mocks base method.
-func (m *MockDynamoDBAPI) DeleteItemWithContext(arg0 context.Context, arg1 *dynamodb.DeleteItemInput, arg2 ...request.Option) (*dynamodb.DeleteItemOutput, error) {
+func (m *MockDynamoDBAPI) DeleteItemWithContext(arg0 aws.Context, arg1 *dynamodb.DeleteItemInput, arg2 ...request.Option) (*dynamodb.DeleteItemOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -505,7 +506,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DeleteResourcePolicyRequest(arg0 any) *go
 }
 
 // DeleteResourcePolicyWithContext mocks base method.
-func (m *MockDynamoDBAPI) DeleteResourcePolicyWithContext(arg0 context.Context, arg1 *dynamodb.DeleteResourcePolicyInput, arg2 ...request.Option) (*dynamodb.DeleteResourcePolicyOutput, error) {
+func (m *MockDynamoDBAPI) DeleteResourcePolicyWithContext(arg0 aws.Context, arg1 *dynamodb.DeleteResourcePolicyInput, arg2 ...request.Option) (*dynamodb.DeleteResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -555,7 +556,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DeleteTableRequest(arg0 any) *gomock.Call
 }
 
 // DeleteTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) DeleteTableWithContext(arg0 context.Context, arg1 *dynamodb.DeleteTableInput, arg2 ...request.Option) (*dynamodb.DeleteTableOutput, error) {
+func (m *MockDynamoDBAPI) DeleteTableWithContext(arg0 aws.Context, arg1 *dynamodb.DeleteTableInput, arg2 ...request.Option) (*dynamodb.DeleteTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -605,7 +606,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeBackupRequest(arg0 any) *gomock.C
 }
 
 // DescribeBackupWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeBackupWithContext(arg0 context.Context, arg1 *dynamodb.DescribeBackupInput, arg2 ...request.Option) (*dynamodb.DescribeBackupOutput, error) {
+func (m *MockDynamoDBAPI) DescribeBackupWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeBackupInput, arg2 ...request.Option) (*dynamodb.DescribeBackupOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -655,7 +656,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeContinuousBackupsRequest(arg0 any
 }
 
 // DescribeContinuousBackupsWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeContinuousBackupsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeContinuousBackupsInput, arg2 ...request.Option) (*dynamodb.DescribeContinuousBackupsOutput, error) {
+func (m *MockDynamoDBAPI) DescribeContinuousBackupsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeContinuousBackupsInput, arg2 ...request.Option) (*dynamodb.DescribeContinuousBackupsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -705,7 +706,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeContributorInsightsRequest(arg0 a
 }
 
 // DescribeContributorInsightsWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeContributorInsightsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeContributorInsightsInput, arg2 ...request.Option) (*dynamodb.DescribeContributorInsightsOutput, error) {
+func (m *MockDynamoDBAPI) DescribeContributorInsightsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeContributorInsightsInput, arg2 ...request.Option) (*dynamodb.DescribeContributorInsightsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -755,7 +756,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeEndpointsRequest(arg0 any) *gomoc
 }
 
 // DescribeEndpointsWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeEndpointsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeEndpointsInput, arg2 ...request.Option) (*dynamodb.DescribeEndpointsOutput, error) {
+func (m *MockDynamoDBAPI) DescribeEndpointsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeEndpointsInput, arg2 ...request.Option) (*dynamodb.DescribeEndpointsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -805,7 +806,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeExportRequest(arg0 any) *gomock.C
 }
 
 // DescribeExportWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeExportWithContext(arg0 context.Context, arg1 *dynamodb.DescribeExportInput, arg2 ...request.Option) (*dynamodb.DescribeExportOutput, error) {
+func (m *MockDynamoDBAPI) DescribeExportWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeExportInput, arg2 ...request.Option) (*dynamodb.DescribeExportOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -885,7 +886,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeGlobalTableSettingsRequest(arg0 a
 }
 
 // DescribeGlobalTableSettingsWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeGlobalTableSettingsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeGlobalTableSettingsInput, arg2 ...request.Option) (*dynamodb.DescribeGlobalTableSettingsOutput, error) {
+func (m *MockDynamoDBAPI) DescribeGlobalTableSettingsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeGlobalTableSettingsInput, arg2 ...request.Option) (*dynamodb.DescribeGlobalTableSettingsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -905,7 +906,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeGlobalTableSettingsWithContext(ar
 }
 
 // DescribeGlobalTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeGlobalTableWithContext(arg0 context.Context, arg1 *dynamodb.DescribeGlobalTableInput, arg2 ...request.Option) (*dynamodb.DescribeGlobalTableOutput, error) {
+func (m *MockDynamoDBAPI) DescribeGlobalTableWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeGlobalTableInput, arg2 ...request.Option) (*dynamodb.DescribeGlobalTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -955,7 +956,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeImportRequest(arg0 any) *gomock.C
 }
 
 // DescribeImportWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeImportWithContext(arg0 context.Context, arg1 *dynamodb.DescribeImportInput, arg2 ...request.Option) (*dynamodb.DescribeImportOutput, error) {
+func (m *MockDynamoDBAPI) DescribeImportWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeImportInput, arg2 ...request.Option) (*dynamodb.DescribeImportOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1005,7 +1006,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeKinesisStreamingDestinationReques
 }
 
 // DescribeKinesisStreamingDestinationWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeKinesisStreamingDestinationWithContext(arg0 context.Context, arg1 *dynamodb.DescribeKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.DescribeKinesisStreamingDestinationOutput, error) {
+func (m *MockDynamoDBAPI) DescribeKinesisStreamingDestinationWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.DescribeKinesisStreamingDestinationOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1055,7 +1056,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeLimitsRequest(arg0 any) *gomock.C
 }
 
 // DescribeLimitsWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeLimitsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeLimitsInput, arg2 ...request.Option) (*dynamodb.DescribeLimitsOutput, error) {
+func (m *MockDynamoDBAPI) DescribeLimitsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeLimitsInput, arg2 ...request.Option) (*dynamodb.DescribeLimitsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1120,7 +1121,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeTableReplicaAutoScalingRequest(ar
 }
 
 // DescribeTableReplicaAutoScalingWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeTableReplicaAutoScalingWithContext(arg0 context.Context, arg1 *dynamodb.DescribeTableReplicaAutoScalingInput, arg2 ...request.Option) (*dynamodb.DescribeTableReplicaAutoScalingOutput, error) {
+func (m *MockDynamoDBAPI) DescribeTableReplicaAutoScalingWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeTableReplicaAutoScalingInput, arg2 ...request.Option) (*dynamodb.DescribeTableReplicaAutoScalingOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1155,7 +1156,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeTableRequest(arg0 any) *gomock.Ca
 }
 
 // DescribeTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeTableWithContext(arg0 context.Context, arg1 *dynamodb.DescribeTableInput, arg2 ...request.Option) (*dynamodb.DescribeTableOutput, error) {
+func (m *MockDynamoDBAPI) DescribeTableWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeTableInput, arg2 ...request.Option) (*dynamodb.DescribeTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1205,7 +1206,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DescribeTimeToLiveRequest(arg0 any) *gomo
 }
 
 // DescribeTimeToLiveWithContext mocks base method.
-func (m *MockDynamoDBAPI) DescribeTimeToLiveWithContext(arg0 context.Context, arg1 *dynamodb.DescribeTimeToLiveInput, arg2 ...request.Option) (*dynamodb.DescribeTimeToLiveOutput, error) {
+func (m *MockDynamoDBAPI) DescribeTimeToLiveWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeTimeToLiveInput, arg2 ...request.Option) (*dynamodb.DescribeTimeToLiveOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1255,7 +1256,7 @@ func (mr *MockDynamoDBAPIMockRecorder) DisableKinesisStreamingDestinationRequest
 }
 
 // DisableKinesisStreamingDestinationWithContext mocks base method.
-func (m *MockDynamoDBAPI) DisableKinesisStreamingDestinationWithContext(arg0 context.Context, arg1 *dynamodb.DisableKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.DisableKinesisStreamingDestinationOutput, error) {
+func (m *MockDynamoDBAPI) DisableKinesisStreamingDestinationWithContext(arg0 aws.Context, arg1 *dynamodb.DisableKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.DisableKinesisStreamingDestinationOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1305,7 +1306,7 @@ func (mr *MockDynamoDBAPIMockRecorder) EnableKinesisStreamingDestinationRequest(
 }
 
 // EnableKinesisStreamingDestinationWithContext mocks base method.
-func (m *MockDynamoDBAPI) EnableKinesisStreamingDestinationWithContext(arg0 context.Context, arg1 *dynamodb.EnableKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.EnableKinesisStreamingDestinationOutput, error) {
+func (m *MockDynamoDBAPI) EnableKinesisStreamingDestinationWithContext(arg0 aws.Context, arg1 *dynamodb.EnableKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.EnableKinesisStreamingDestinationOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1355,7 +1356,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ExecuteStatementRequest(arg0 any) *gomock
 }
 
 // ExecuteStatementWithContext mocks base method.
-func (m *MockDynamoDBAPI) ExecuteStatementWithContext(arg0 context.Context, arg1 *dynamodb.ExecuteStatementInput, arg2 ...request.Option) (*dynamodb.ExecuteStatementOutput, error) {
+func (m *MockDynamoDBAPI) ExecuteStatementWithContext(arg0 aws.Context, arg1 *dynamodb.ExecuteStatementInput, arg2 ...request.Option) (*dynamodb.ExecuteStatementOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1405,7 +1406,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ExecuteTransactionRequest(arg0 any) *gomo
 }
 
 // ExecuteTransactionWithContext mocks base method.
-func (m *MockDynamoDBAPI) ExecuteTransactionWithContext(arg0 context.Context, arg1 *dynamodb.ExecuteTransactionInput, arg2 ...request.Option) (*dynamodb.ExecuteTransactionOutput, error) {
+func (m *MockDynamoDBAPI) ExecuteTransactionWithContext(arg0 aws.Context, arg1 *dynamodb.ExecuteTransactionInput, arg2 ...request.Option) (*dynamodb.ExecuteTransactionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1455,7 +1456,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ExportTableToPointInTimeRequest(arg0 any)
 }
 
 // ExportTableToPointInTimeWithContext mocks base method.
-func (m *MockDynamoDBAPI) ExportTableToPointInTimeWithContext(arg0 context.Context, arg1 *dynamodb.ExportTableToPointInTimeInput, arg2 ...request.Option) (*dynamodb.ExportTableToPointInTimeOutput, error) {
+func (m *MockDynamoDBAPI) ExportTableToPointInTimeWithContext(arg0 aws.Context, arg1 *dynamodb.ExportTableToPointInTimeInput, arg2 ...request.Option) (*dynamodb.ExportTableToPointInTimeOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1505,7 +1506,7 @@ func (mr *MockDynamoDBAPIMockRecorder) GetItemRequest(arg0 any) *gomock.Call {
 }
 
 // GetItemWithContext mocks base method.
-func (m *MockDynamoDBAPI) GetItemWithContext(arg0 context.Context, arg1 *dynamodb.GetItemInput, arg2 ...request.Option) (*dynamodb.GetItemOutput, error) {
+func (m *MockDynamoDBAPI) GetItemWithContext(arg0 aws.Context, arg1 *dynamodb.GetItemInput, arg2 ...request.Option) (*dynamodb.GetItemOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1555,7 +1556,7 @@ func (mr *MockDynamoDBAPIMockRecorder) GetResourcePolicyRequest(arg0 any) *gomoc
 }
 
 // GetResourcePolicyWithContext mocks base method.
-func (m *MockDynamoDBAPI) GetResourcePolicyWithContext(arg0 context.Context, arg1 *dynamodb.GetResourcePolicyInput, arg2 ...request.Option) (*dynamodb.GetResourcePolicyOutput, error) {
+func (m *MockDynamoDBAPI) GetResourcePolicyWithContext(arg0 aws.Context, arg1 *dynamodb.GetResourcePolicyInput, arg2 ...request.Option) (*dynamodb.GetResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1605,7 +1606,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ImportTableRequest(arg0 any) *gomock.Call
 }
 
 // ImportTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) ImportTableWithContext(arg0 context.Context, arg1 *dynamodb.ImportTableInput, arg2 ...request.Option) (*dynamodb.ImportTableOutput, error) {
+func (m *MockDynamoDBAPI) ImportTableWithContext(arg0 aws.Context, arg1 *dynamodb.ImportTableInput, arg2 ...request.Option) (*dynamodb.ImportTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1655,7 +1656,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListBackupsRequest(arg0 any) *gomock.Call
 }
 
 // ListBackupsWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListBackupsWithContext(arg0 context.Context, arg1 *dynamodb.ListBackupsInput, arg2 ...request.Option) (*dynamodb.ListBackupsOutput, error) {
+func (m *MockDynamoDBAPI) ListBackupsWithContext(arg0 aws.Context, arg1 *dynamodb.ListBackupsInput, arg2 ...request.Option) (*dynamodb.ListBackupsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1704,7 +1705,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListContributorInsightsPages(arg0, arg1 a
 }
 
 // ListContributorInsightsPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListContributorInsightsPagesWithContext(arg0 context.Context, arg1 *dynamodb.ListContributorInsightsInput, arg2 func(*dynamodb.ListContributorInsightsOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) ListContributorInsightsPagesWithContext(arg0 aws.Context, arg1 *dynamodb.ListContributorInsightsInput, arg2 func(*dynamodb.ListContributorInsightsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1738,7 +1739,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListContributorInsightsRequest(arg0 any) 
 }
 
 // ListContributorInsightsWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListContributorInsightsWithContext(arg0 context.Context, arg1 *dynamodb.ListContributorInsightsInput, arg2 ...request.Option) (*dynamodb.ListContributorInsightsOutput, error) {
+func (m *MockDynamoDBAPI) ListContributorInsightsWithContext(arg0 aws.Context, arg1 *dynamodb.ListContributorInsightsInput, arg2 ...request.Option) (*dynamodb.ListContributorInsightsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1787,7 +1788,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListExportsPages(arg0, arg1 any) *gomock.
 }
 
 // ListExportsPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListExportsPagesWithContext(arg0 context.Context, arg1 *dynamodb.ListExportsInput, arg2 func(*dynamodb.ListExportsOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) ListExportsPagesWithContext(arg0 aws.Context, arg1 *dynamodb.ListExportsInput, arg2 func(*dynamodb.ListExportsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1821,7 +1822,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListExportsRequest(arg0 any) *gomock.Call
 }
 
 // ListExportsWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListExportsWithContext(arg0 context.Context, arg1 *dynamodb.ListExportsInput, arg2 ...request.Option) (*dynamodb.ListExportsOutput, error) {
+func (m *MockDynamoDBAPI) ListExportsWithContext(arg0 aws.Context, arg1 *dynamodb.ListExportsInput, arg2 ...request.Option) (*dynamodb.ListExportsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1871,7 +1872,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListGlobalTablesRequest(arg0 any) *gomock
 }
 
 // ListGlobalTablesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListGlobalTablesWithContext(arg0 context.Context, arg1 *dynamodb.ListGlobalTablesInput, arg2 ...request.Option) (*dynamodb.ListGlobalTablesOutput, error) {
+func (m *MockDynamoDBAPI) ListGlobalTablesWithContext(arg0 aws.Context, arg1 *dynamodb.ListGlobalTablesInput, arg2 ...request.Option) (*dynamodb.ListGlobalTablesOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1920,7 +1921,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListImportsPages(arg0, arg1 any) *gomock.
 }
 
 // ListImportsPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListImportsPagesWithContext(arg0 context.Context, arg1 *dynamodb.ListImportsInput, arg2 func(*dynamodb.ListImportsOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) ListImportsPagesWithContext(arg0 aws.Context, arg1 *dynamodb.ListImportsInput, arg2 func(*dynamodb.ListImportsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1954,7 +1955,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListImportsRequest(arg0 any) *gomock.Call
 }
 
 // ListImportsWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListImportsWithContext(arg0 context.Context, arg1 *dynamodb.ListImportsInput, arg2 ...request.Option) (*dynamodb.ListImportsOutput, error) {
+func (m *MockDynamoDBAPI) ListImportsWithContext(arg0 aws.Context, arg1 *dynamodb.ListImportsInput, arg2 ...request.Option) (*dynamodb.ListImportsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2003,7 +2004,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListTablesPages(arg0, arg1 any) *gomock.C
 }
 
 // ListTablesPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListTablesPagesWithContext(arg0 context.Context, arg1 *dynamodb.ListTablesInput, arg2 func(*dynamodb.ListTablesOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) ListTablesPagesWithContext(arg0 aws.Context, arg1 *dynamodb.ListTablesInput, arg2 func(*dynamodb.ListTablesOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -2037,7 +2038,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListTablesRequest(arg0 any) *gomock.Call 
 }
 
 // ListTablesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListTablesWithContext(arg0 context.Context, arg1 *dynamodb.ListTablesInput, arg2 ...request.Option) (*dynamodb.ListTablesOutput, error) {
+func (m *MockDynamoDBAPI) ListTablesWithContext(arg0 aws.Context, arg1 *dynamodb.ListTablesInput, arg2 ...request.Option) (*dynamodb.ListTablesOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2087,7 +2088,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ListTagsOfResourceRequest(arg0 any) *gomo
 }
 
 // ListTagsOfResourceWithContext mocks base method.
-func (m *MockDynamoDBAPI) ListTagsOfResourceWithContext(arg0 context.Context, arg1 *dynamodb.ListTagsOfResourceInput, arg2 ...request.Option) (*dynamodb.ListTagsOfResourceOutput, error) {
+func (m *MockDynamoDBAPI) ListTagsOfResourceWithContext(arg0 aws.Context, arg1 *dynamodb.ListTagsOfResourceInput, arg2 ...request.Option) (*dynamodb.ListTagsOfResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2137,7 +2138,7 @@ func (mr *MockDynamoDBAPIMockRecorder) PutItemRequest(arg0 any) *gomock.Call {
 }
 
 // PutItemWithContext mocks base method.
-func (m *MockDynamoDBAPI) PutItemWithContext(arg0 context.Context, arg1 *dynamodb.PutItemInput, arg2 ...request.Option) (*dynamodb.PutItemOutput, error) {
+func (m *MockDynamoDBAPI) PutItemWithContext(arg0 aws.Context, arg1 *dynamodb.PutItemInput, arg2 ...request.Option) (*dynamodb.PutItemOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2187,7 +2188,7 @@ func (mr *MockDynamoDBAPIMockRecorder) PutResourcePolicyRequest(arg0 any) *gomoc
 }
 
 // PutResourcePolicyWithContext mocks base method.
-func (m *MockDynamoDBAPI) PutResourcePolicyWithContext(arg0 context.Context, arg1 *dynamodb.PutResourcePolicyInput, arg2 ...request.Option) (*dynamodb.PutResourcePolicyOutput, error) {
+func (m *MockDynamoDBAPI) PutResourcePolicyWithContext(arg0 aws.Context, arg1 *dynamodb.PutResourcePolicyInput, arg2 ...request.Option) (*dynamodb.PutResourcePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2236,7 +2237,7 @@ func (mr *MockDynamoDBAPIMockRecorder) QueryPages(arg0, arg1 any) *gomock.Call {
 }
 
 // QueryPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) QueryPagesWithContext(arg0 context.Context, arg1 *dynamodb.QueryInput, arg2 func(*dynamodb.QueryOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) QueryPagesWithContext(arg0 aws.Context, arg1 *dynamodb.QueryInput, arg2 func(*dynamodb.QueryOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -2270,7 +2271,7 @@ func (mr *MockDynamoDBAPIMockRecorder) QueryRequest(arg0 any) *gomock.Call {
 }
 
 // QueryWithContext mocks base method.
-func (m *MockDynamoDBAPI) QueryWithContext(arg0 context.Context, arg1 *dynamodb.QueryInput, arg2 ...request.Option) (*dynamodb.QueryOutput, error) {
+func (m *MockDynamoDBAPI) QueryWithContext(arg0 aws.Context, arg1 *dynamodb.QueryInput, arg2 ...request.Option) (*dynamodb.QueryOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2320,7 +2321,7 @@ func (mr *MockDynamoDBAPIMockRecorder) RestoreTableFromBackupRequest(arg0 any) *
 }
 
 // RestoreTableFromBackupWithContext mocks base method.
-func (m *MockDynamoDBAPI) RestoreTableFromBackupWithContext(arg0 context.Context, arg1 *dynamodb.RestoreTableFromBackupInput, arg2 ...request.Option) (*dynamodb.RestoreTableFromBackupOutput, error) {
+func (m *MockDynamoDBAPI) RestoreTableFromBackupWithContext(arg0 aws.Context, arg1 *dynamodb.RestoreTableFromBackupInput, arg2 ...request.Option) (*dynamodb.RestoreTableFromBackupOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2370,7 +2371,7 @@ func (mr *MockDynamoDBAPIMockRecorder) RestoreTableToPointInTimeRequest(arg0 any
 }
 
 // RestoreTableToPointInTimeWithContext mocks base method.
-func (m *MockDynamoDBAPI) RestoreTableToPointInTimeWithContext(arg0 context.Context, arg1 *dynamodb.RestoreTableToPointInTimeInput, arg2 ...request.Option) (*dynamodb.RestoreTableToPointInTimeOutput, error) {
+func (m *MockDynamoDBAPI) RestoreTableToPointInTimeWithContext(arg0 aws.Context, arg1 *dynamodb.RestoreTableToPointInTimeInput, arg2 ...request.Option) (*dynamodb.RestoreTableToPointInTimeOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2419,7 +2420,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ScanPages(arg0, arg1 any) *gomock.Call {
 }
 
 // ScanPagesWithContext mocks base method.
-func (m *MockDynamoDBAPI) ScanPagesWithContext(arg0 context.Context, arg1 *dynamodb.ScanInput, arg2 func(*dynamodb.ScanOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockDynamoDBAPI) ScanPagesWithContext(arg0 aws.Context, arg1 *dynamodb.ScanInput, arg2 func(*dynamodb.ScanOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -2453,7 +2454,7 @@ func (mr *MockDynamoDBAPIMockRecorder) ScanRequest(arg0 any) *gomock.Call {
 }
 
 // ScanWithContext mocks base method.
-func (m *MockDynamoDBAPI) ScanWithContext(arg0 context.Context, arg1 *dynamodb.ScanInput, arg2 ...request.Option) (*dynamodb.ScanOutput, error) {
+func (m *MockDynamoDBAPI) ScanWithContext(arg0 aws.Context, arg1 *dynamodb.ScanInput, arg2 ...request.Option) (*dynamodb.ScanOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2503,7 +2504,7 @@ func (mr *MockDynamoDBAPIMockRecorder) TagResourceRequest(arg0 any) *gomock.Call
 }
 
 // TagResourceWithContext mocks base method.
-func (m *MockDynamoDBAPI) TagResourceWithContext(arg0 context.Context, arg1 *dynamodb.TagResourceInput, arg2 ...request.Option) (*dynamodb.TagResourceOutput, error) {
+func (m *MockDynamoDBAPI) TagResourceWithContext(arg0 aws.Context, arg1 *dynamodb.TagResourceInput, arg2 ...request.Option) (*dynamodb.TagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2553,7 +2554,7 @@ func (mr *MockDynamoDBAPIMockRecorder) TransactGetItemsRequest(arg0 any) *gomock
 }
 
 // TransactGetItemsWithContext mocks base method.
-func (m *MockDynamoDBAPI) TransactGetItemsWithContext(arg0 context.Context, arg1 *dynamodb.TransactGetItemsInput, arg2 ...request.Option) (*dynamodb.TransactGetItemsOutput, error) {
+func (m *MockDynamoDBAPI) TransactGetItemsWithContext(arg0 aws.Context, arg1 *dynamodb.TransactGetItemsInput, arg2 ...request.Option) (*dynamodb.TransactGetItemsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2603,7 +2604,7 @@ func (mr *MockDynamoDBAPIMockRecorder) TransactWriteItemsRequest(arg0 any) *gomo
 }
 
 // TransactWriteItemsWithContext mocks base method.
-func (m *MockDynamoDBAPI) TransactWriteItemsWithContext(arg0 context.Context, arg1 *dynamodb.TransactWriteItemsInput, arg2 ...request.Option) (*dynamodb.TransactWriteItemsOutput, error) {
+func (m *MockDynamoDBAPI) TransactWriteItemsWithContext(arg0 aws.Context, arg1 *dynamodb.TransactWriteItemsInput, arg2 ...request.Option) (*dynamodb.TransactWriteItemsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2653,7 +2654,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UntagResourceRequest(arg0 any) *gomock.Ca
 }
 
 // UntagResourceWithContext mocks base method.
-func (m *MockDynamoDBAPI) UntagResourceWithContext(arg0 context.Context, arg1 *dynamodb.UntagResourceInput, arg2 ...request.Option) (*dynamodb.UntagResourceOutput, error) {
+func (m *MockDynamoDBAPI) UntagResourceWithContext(arg0 aws.Context, arg1 *dynamodb.UntagResourceInput, arg2 ...request.Option) (*dynamodb.UntagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2703,7 +2704,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateContinuousBackupsRequest(arg0 any) 
 }
 
 // UpdateContinuousBackupsWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateContinuousBackupsWithContext(arg0 context.Context, arg1 *dynamodb.UpdateContinuousBackupsInput, arg2 ...request.Option) (*dynamodb.UpdateContinuousBackupsOutput, error) {
+func (m *MockDynamoDBAPI) UpdateContinuousBackupsWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateContinuousBackupsInput, arg2 ...request.Option) (*dynamodb.UpdateContinuousBackupsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2753,7 +2754,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateContributorInsightsRequest(arg0 any
 }
 
 // UpdateContributorInsightsWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateContributorInsightsWithContext(arg0 context.Context, arg1 *dynamodb.UpdateContributorInsightsInput, arg2 ...request.Option) (*dynamodb.UpdateContributorInsightsOutput, error) {
+func (m *MockDynamoDBAPI) UpdateContributorInsightsWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateContributorInsightsInput, arg2 ...request.Option) (*dynamodb.UpdateContributorInsightsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2833,7 +2834,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateGlobalTableSettingsRequest(arg0 any
 }
 
 // UpdateGlobalTableSettingsWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateGlobalTableSettingsWithContext(arg0 context.Context, arg1 *dynamodb.UpdateGlobalTableSettingsInput, arg2 ...request.Option) (*dynamodb.UpdateGlobalTableSettingsOutput, error) {
+func (m *MockDynamoDBAPI) UpdateGlobalTableSettingsWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateGlobalTableSettingsInput, arg2 ...request.Option) (*dynamodb.UpdateGlobalTableSettingsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2853,7 +2854,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateGlobalTableSettingsWithContext(arg0
 }
 
 // UpdateGlobalTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateGlobalTableWithContext(arg0 context.Context, arg1 *dynamodb.UpdateGlobalTableInput, arg2 ...request.Option) (*dynamodb.UpdateGlobalTableOutput, error) {
+func (m *MockDynamoDBAPI) UpdateGlobalTableWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateGlobalTableInput, arg2 ...request.Option) (*dynamodb.UpdateGlobalTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2903,7 +2904,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateItemRequest(arg0 any) *gomock.Call 
 }
 
 // UpdateItemWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateItemWithContext(arg0 context.Context, arg1 *dynamodb.UpdateItemInput, arg2 ...request.Option) (*dynamodb.UpdateItemOutput, error) {
+func (m *MockDynamoDBAPI) UpdateItemWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateItemInput, arg2 ...request.Option) (*dynamodb.UpdateItemOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2953,7 +2954,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateKinesisStreamingDestinationRequest(
 }
 
 // UpdateKinesisStreamingDestinationWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateKinesisStreamingDestinationWithContext(arg0 context.Context, arg1 *dynamodb.UpdateKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.UpdateKinesisStreamingDestinationOutput, error) {
+func (m *MockDynamoDBAPI) UpdateKinesisStreamingDestinationWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateKinesisStreamingDestinationInput, arg2 ...request.Option) (*dynamodb.UpdateKinesisStreamingDestinationOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -3018,7 +3019,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateTableReplicaAutoScalingRequest(arg0
 }
 
 // UpdateTableReplicaAutoScalingWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateTableReplicaAutoScalingWithContext(arg0 context.Context, arg1 *dynamodb.UpdateTableReplicaAutoScalingInput, arg2 ...request.Option) (*dynamodb.UpdateTableReplicaAutoScalingOutput, error) {
+func (m *MockDynamoDBAPI) UpdateTableReplicaAutoScalingWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateTableReplicaAutoScalingInput, arg2 ...request.Option) (*dynamodb.UpdateTableReplicaAutoScalingOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -3053,7 +3054,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateTableRequest(arg0 any) *gomock.Call
 }
 
 // UpdateTableWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateTableWithContext(arg0 context.Context, arg1 *dynamodb.UpdateTableInput, arg2 ...request.Option) (*dynamodb.UpdateTableOutput, error) {
+func (m *MockDynamoDBAPI) UpdateTableWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateTableInput, arg2 ...request.Option) (*dynamodb.UpdateTableOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -3103,7 +3104,7 @@ func (mr *MockDynamoDBAPIMockRecorder) UpdateTimeToLiveRequest(arg0 any) *gomock
 }
 
 // UpdateTimeToLiveWithContext mocks base method.
-func (m *MockDynamoDBAPI) UpdateTimeToLiveWithContext(arg0 context.Context, arg1 *dynamodb.UpdateTimeToLiveInput, arg2 ...request.Option) (*dynamodb.UpdateTimeToLiveOutput, error) {
+func (m *MockDynamoDBAPI) UpdateTimeToLiveWithContext(arg0 aws.Context, arg1 *dynamodb.UpdateTimeToLiveInput, arg2 ...request.Option) (*dynamodb.UpdateTimeToLiveOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -3137,7 +3138,7 @@ func (mr *MockDynamoDBAPIMockRecorder) WaitUntilTableExists(arg0 any) *gomock.Ca
 }
 
 // WaitUntilTableExistsWithContext mocks base method.
-func (m *MockDynamoDBAPI) WaitUntilTableExistsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeTableInput, arg2 ...request.WaiterOption) error {
+func (m *MockDynamoDBAPI) WaitUntilTableExistsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeTableInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -3170,7 +3171,7 @@ func (mr *MockDynamoDBAPIMockRecorder) WaitUntilTableNotExists(arg0 any) *gomock
 }
 
 // WaitUntilTableNotExistsWithContext mocks base method.
-func (m *MockDynamoDBAPI) WaitUntilTableNotExistsWithContext(arg0 context.Context, arg1 *dynamodb.DescribeTableInput, arg2 ...request.WaiterOption) error {
+func (m *MockDynamoDBAPI) WaitUntilTableNotExistsWithContext(arg0 aws.Context, arg1 *dynamodb.DescribeTableInput, arg2 ...request.WaiterOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {

--- a/internal/mockaws/kmsmock.go
+++ b/internal/mockaws/kmsmock.go
@@ -10,9 +10,9 @@
 package mockaws
 
 import (
-	context "context"
 	reflect "reflect"
 
+	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	kms "github.com/aws/aws-sdk-go/service/kms"
 	gomock "go.uber.org/mock/gomock"
@@ -22,6 +22,7 @@ import (
 type MockKMSAPI struct {
 	ctrl     *gomock.Controller
 	recorder *MockKMSAPIMockRecorder
+	isgomock struct{}
 }
 
 // MockKMSAPIMockRecorder is the mock recorder for MockKMSAPI.
@@ -72,7 +73,7 @@ func (mr *MockKMSAPIMockRecorder) CancelKeyDeletionRequest(arg0 any) *gomock.Cal
 }
 
 // CancelKeyDeletionWithContext mocks base method.
-func (m *MockKMSAPI) CancelKeyDeletionWithContext(arg0 context.Context, arg1 *kms.CancelKeyDeletionInput, arg2 ...request.Option) (*kms.CancelKeyDeletionOutput, error) {
+func (m *MockKMSAPI) CancelKeyDeletionWithContext(arg0 aws.Context, arg1 *kms.CancelKeyDeletionInput, arg2 ...request.Option) (*kms.CancelKeyDeletionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -122,7 +123,7 @@ func (mr *MockKMSAPIMockRecorder) ConnectCustomKeyStoreRequest(arg0 any) *gomock
 }
 
 // ConnectCustomKeyStoreWithContext mocks base method.
-func (m *MockKMSAPI) ConnectCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.ConnectCustomKeyStoreInput, arg2 ...request.Option) (*kms.ConnectCustomKeyStoreOutput, error) {
+func (m *MockKMSAPI) ConnectCustomKeyStoreWithContext(arg0 aws.Context, arg1 *kms.ConnectCustomKeyStoreInput, arg2 ...request.Option) (*kms.ConnectCustomKeyStoreOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -172,7 +173,7 @@ func (mr *MockKMSAPIMockRecorder) CreateAliasRequest(arg0 any) *gomock.Call {
 }
 
 // CreateAliasWithContext mocks base method.
-func (m *MockKMSAPI) CreateAliasWithContext(arg0 context.Context, arg1 *kms.CreateAliasInput, arg2 ...request.Option) (*kms.CreateAliasOutput, error) {
+func (m *MockKMSAPI) CreateAliasWithContext(arg0 aws.Context, arg1 *kms.CreateAliasInput, arg2 ...request.Option) (*kms.CreateAliasOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -222,7 +223,7 @@ func (mr *MockKMSAPIMockRecorder) CreateCustomKeyStoreRequest(arg0 any) *gomock.
 }
 
 // CreateCustomKeyStoreWithContext mocks base method.
-func (m *MockKMSAPI) CreateCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.CreateCustomKeyStoreInput, arg2 ...request.Option) (*kms.CreateCustomKeyStoreOutput, error) {
+func (m *MockKMSAPI) CreateCustomKeyStoreWithContext(arg0 aws.Context, arg1 *kms.CreateCustomKeyStoreInput, arg2 ...request.Option) (*kms.CreateCustomKeyStoreOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -272,7 +273,7 @@ func (mr *MockKMSAPIMockRecorder) CreateGrantRequest(arg0 any) *gomock.Call {
 }
 
 // CreateGrantWithContext mocks base method.
-func (m *MockKMSAPI) CreateGrantWithContext(arg0 context.Context, arg1 *kms.CreateGrantInput, arg2 ...request.Option) (*kms.CreateGrantOutput, error) {
+func (m *MockKMSAPI) CreateGrantWithContext(arg0 aws.Context, arg1 *kms.CreateGrantInput, arg2 ...request.Option) (*kms.CreateGrantOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -322,7 +323,7 @@ func (mr *MockKMSAPIMockRecorder) CreateKeyRequest(arg0 any) *gomock.Call {
 }
 
 // CreateKeyWithContext mocks base method.
-func (m *MockKMSAPI) CreateKeyWithContext(arg0 context.Context, arg1 *kms.CreateKeyInput, arg2 ...request.Option) (*kms.CreateKeyOutput, error) {
+func (m *MockKMSAPI) CreateKeyWithContext(arg0 aws.Context, arg1 *kms.CreateKeyInput, arg2 ...request.Option) (*kms.CreateKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -372,7 +373,7 @@ func (mr *MockKMSAPIMockRecorder) DecryptRequest(arg0 any) *gomock.Call {
 }
 
 // DecryptWithContext mocks base method.
-func (m *MockKMSAPI) DecryptWithContext(arg0 context.Context, arg1 *kms.DecryptInput, arg2 ...request.Option) (*kms.DecryptOutput, error) {
+func (m *MockKMSAPI) DecryptWithContext(arg0 aws.Context, arg1 *kms.DecryptInput, arg2 ...request.Option) (*kms.DecryptOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -422,7 +423,7 @@ func (mr *MockKMSAPIMockRecorder) DeleteAliasRequest(arg0 any) *gomock.Call {
 }
 
 // DeleteAliasWithContext mocks base method.
-func (m *MockKMSAPI) DeleteAliasWithContext(arg0 context.Context, arg1 *kms.DeleteAliasInput, arg2 ...request.Option) (*kms.DeleteAliasOutput, error) {
+func (m *MockKMSAPI) DeleteAliasWithContext(arg0 aws.Context, arg1 *kms.DeleteAliasInput, arg2 ...request.Option) (*kms.DeleteAliasOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -472,7 +473,7 @@ func (mr *MockKMSAPIMockRecorder) DeleteCustomKeyStoreRequest(arg0 any) *gomock.
 }
 
 // DeleteCustomKeyStoreWithContext mocks base method.
-func (m *MockKMSAPI) DeleteCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.DeleteCustomKeyStoreInput, arg2 ...request.Option) (*kms.DeleteCustomKeyStoreOutput, error) {
+func (m *MockKMSAPI) DeleteCustomKeyStoreWithContext(arg0 aws.Context, arg1 *kms.DeleteCustomKeyStoreInput, arg2 ...request.Option) (*kms.DeleteCustomKeyStoreOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -522,7 +523,7 @@ func (mr *MockKMSAPIMockRecorder) DeleteImportedKeyMaterialRequest(arg0 any) *go
 }
 
 // DeleteImportedKeyMaterialWithContext mocks base method.
-func (m *MockKMSAPI) DeleteImportedKeyMaterialWithContext(arg0 context.Context, arg1 *kms.DeleteImportedKeyMaterialInput, arg2 ...request.Option) (*kms.DeleteImportedKeyMaterialOutput, error) {
+func (m *MockKMSAPI) DeleteImportedKeyMaterialWithContext(arg0 aws.Context, arg1 *kms.DeleteImportedKeyMaterialInput, arg2 ...request.Option) (*kms.DeleteImportedKeyMaterialOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -572,7 +573,7 @@ func (mr *MockKMSAPIMockRecorder) DeriveSharedSecretRequest(arg0 any) *gomock.Ca
 }
 
 // DeriveSharedSecretWithContext mocks base method.
-func (m *MockKMSAPI) DeriveSharedSecretWithContext(arg0 context.Context, arg1 *kms.DeriveSharedSecretInput, arg2 ...request.Option) (*kms.DeriveSharedSecretOutput, error) {
+func (m *MockKMSAPI) DeriveSharedSecretWithContext(arg0 aws.Context, arg1 *kms.DeriveSharedSecretInput, arg2 ...request.Option) (*kms.DeriveSharedSecretOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -621,7 +622,7 @@ func (mr *MockKMSAPIMockRecorder) DescribeCustomKeyStoresPages(arg0, arg1 any) *
 }
 
 // DescribeCustomKeyStoresPagesWithContext mocks base method.
-func (m *MockKMSAPI) DescribeCustomKeyStoresPagesWithContext(arg0 context.Context, arg1 *kms.DescribeCustomKeyStoresInput, arg2 func(*kms.DescribeCustomKeyStoresOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) DescribeCustomKeyStoresPagesWithContext(arg0 aws.Context, arg1 *kms.DescribeCustomKeyStoresInput, arg2 func(*kms.DescribeCustomKeyStoresOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -655,7 +656,7 @@ func (mr *MockKMSAPIMockRecorder) DescribeCustomKeyStoresRequest(arg0 any) *gomo
 }
 
 // DescribeCustomKeyStoresWithContext mocks base method.
-func (m *MockKMSAPI) DescribeCustomKeyStoresWithContext(arg0 context.Context, arg1 *kms.DescribeCustomKeyStoresInput, arg2 ...request.Option) (*kms.DescribeCustomKeyStoresOutput, error) {
+func (m *MockKMSAPI) DescribeCustomKeyStoresWithContext(arg0 aws.Context, arg1 *kms.DescribeCustomKeyStoresInput, arg2 ...request.Option) (*kms.DescribeCustomKeyStoresOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -705,7 +706,7 @@ func (mr *MockKMSAPIMockRecorder) DescribeKeyRequest(arg0 any) *gomock.Call {
 }
 
 // DescribeKeyWithContext mocks base method.
-func (m *MockKMSAPI) DescribeKeyWithContext(arg0 context.Context, arg1 *kms.DescribeKeyInput, arg2 ...request.Option) (*kms.DescribeKeyOutput, error) {
+func (m *MockKMSAPI) DescribeKeyWithContext(arg0 aws.Context, arg1 *kms.DescribeKeyInput, arg2 ...request.Option) (*kms.DescribeKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -785,7 +786,7 @@ func (mr *MockKMSAPIMockRecorder) DisableKeyRotationRequest(arg0 any) *gomock.Ca
 }
 
 // DisableKeyRotationWithContext mocks base method.
-func (m *MockKMSAPI) DisableKeyRotationWithContext(arg0 context.Context, arg1 *kms.DisableKeyRotationInput, arg2 ...request.Option) (*kms.DisableKeyRotationOutput, error) {
+func (m *MockKMSAPI) DisableKeyRotationWithContext(arg0 aws.Context, arg1 *kms.DisableKeyRotationInput, arg2 ...request.Option) (*kms.DisableKeyRotationOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -805,7 +806,7 @@ func (mr *MockKMSAPIMockRecorder) DisableKeyRotationWithContext(arg0, arg1 any, 
 }
 
 // DisableKeyWithContext mocks base method.
-func (m *MockKMSAPI) DisableKeyWithContext(arg0 context.Context, arg1 *kms.DisableKeyInput, arg2 ...request.Option) (*kms.DisableKeyOutput, error) {
+func (m *MockKMSAPI) DisableKeyWithContext(arg0 aws.Context, arg1 *kms.DisableKeyInput, arg2 ...request.Option) (*kms.DisableKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -855,7 +856,7 @@ func (mr *MockKMSAPIMockRecorder) DisconnectCustomKeyStoreRequest(arg0 any) *gom
 }
 
 // DisconnectCustomKeyStoreWithContext mocks base method.
-func (m *MockKMSAPI) DisconnectCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.DisconnectCustomKeyStoreInput, arg2 ...request.Option) (*kms.DisconnectCustomKeyStoreOutput, error) {
+func (m *MockKMSAPI) DisconnectCustomKeyStoreWithContext(arg0 aws.Context, arg1 *kms.DisconnectCustomKeyStoreInput, arg2 ...request.Option) (*kms.DisconnectCustomKeyStoreOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -935,7 +936,7 @@ func (mr *MockKMSAPIMockRecorder) EnableKeyRotationRequest(arg0 any) *gomock.Cal
 }
 
 // EnableKeyRotationWithContext mocks base method.
-func (m *MockKMSAPI) EnableKeyRotationWithContext(arg0 context.Context, arg1 *kms.EnableKeyRotationInput, arg2 ...request.Option) (*kms.EnableKeyRotationOutput, error) {
+func (m *MockKMSAPI) EnableKeyRotationWithContext(arg0 aws.Context, arg1 *kms.EnableKeyRotationInput, arg2 ...request.Option) (*kms.EnableKeyRotationOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -955,7 +956,7 @@ func (mr *MockKMSAPIMockRecorder) EnableKeyRotationWithContext(arg0, arg1 any, a
 }
 
 // EnableKeyWithContext mocks base method.
-func (m *MockKMSAPI) EnableKeyWithContext(arg0 context.Context, arg1 *kms.EnableKeyInput, arg2 ...request.Option) (*kms.EnableKeyOutput, error) {
+func (m *MockKMSAPI) EnableKeyWithContext(arg0 aws.Context, arg1 *kms.EnableKeyInput, arg2 ...request.Option) (*kms.EnableKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1005,7 +1006,7 @@ func (mr *MockKMSAPIMockRecorder) EncryptRequest(arg0 any) *gomock.Call {
 }
 
 // EncryptWithContext mocks base method.
-func (m *MockKMSAPI) EncryptWithContext(arg0 context.Context, arg1 *kms.EncryptInput, arg2 ...request.Option) (*kms.EncryptOutput, error) {
+func (m *MockKMSAPI) EncryptWithContext(arg0 aws.Context, arg1 *kms.EncryptInput, arg2 ...request.Option) (*kms.EncryptOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1070,7 +1071,7 @@ func (mr *MockKMSAPIMockRecorder) GenerateDataKeyPairRequest(arg0 any) *gomock.C
 }
 
 // GenerateDataKeyPairWithContext mocks base method.
-func (m *MockKMSAPI) GenerateDataKeyPairWithContext(arg0 context.Context, arg1 *kms.GenerateDataKeyPairInput, arg2 ...request.Option) (*kms.GenerateDataKeyPairOutput, error) {
+func (m *MockKMSAPI) GenerateDataKeyPairWithContext(arg0 aws.Context, arg1 *kms.GenerateDataKeyPairInput, arg2 ...request.Option) (*kms.GenerateDataKeyPairOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1120,7 +1121,7 @@ func (mr *MockKMSAPIMockRecorder) GenerateDataKeyPairWithoutPlaintextRequest(arg
 }
 
 // GenerateDataKeyPairWithoutPlaintextWithContext mocks base method.
-func (m *MockKMSAPI) GenerateDataKeyPairWithoutPlaintextWithContext(arg0 context.Context, arg1 *kms.GenerateDataKeyPairWithoutPlaintextInput, arg2 ...request.Option) (*kms.GenerateDataKeyPairWithoutPlaintextOutput, error) {
+func (m *MockKMSAPI) GenerateDataKeyPairWithoutPlaintextWithContext(arg0 aws.Context, arg1 *kms.GenerateDataKeyPairWithoutPlaintextInput, arg2 ...request.Option) (*kms.GenerateDataKeyPairWithoutPlaintextOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1155,7 +1156,7 @@ func (mr *MockKMSAPIMockRecorder) GenerateDataKeyRequest(arg0 any) *gomock.Call 
 }
 
 // GenerateDataKeyWithContext mocks base method.
-func (m *MockKMSAPI) GenerateDataKeyWithContext(arg0 context.Context, arg1 *kms.GenerateDataKeyInput, arg2 ...request.Option) (*kms.GenerateDataKeyOutput, error) {
+func (m *MockKMSAPI) GenerateDataKeyWithContext(arg0 aws.Context, arg1 *kms.GenerateDataKeyInput, arg2 ...request.Option) (*kms.GenerateDataKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1205,7 +1206,7 @@ func (mr *MockKMSAPIMockRecorder) GenerateDataKeyWithoutPlaintextRequest(arg0 an
 }
 
 // GenerateDataKeyWithoutPlaintextWithContext mocks base method.
-func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintextWithContext(arg0 context.Context, arg1 *kms.GenerateDataKeyWithoutPlaintextInput, arg2 ...request.Option) (*kms.GenerateDataKeyWithoutPlaintextOutput, error) {
+func (m *MockKMSAPI) GenerateDataKeyWithoutPlaintextWithContext(arg0 aws.Context, arg1 *kms.GenerateDataKeyWithoutPlaintextInput, arg2 ...request.Option) (*kms.GenerateDataKeyWithoutPlaintextOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1255,7 +1256,7 @@ func (mr *MockKMSAPIMockRecorder) GenerateMacRequest(arg0 any) *gomock.Call {
 }
 
 // GenerateMacWithContext mocks base method.
-func (m *MockKMSAPI) GenerateMacWithContext(arg0 context.Context, arg1 *kms.GenerateMacInput, arg2 ...request.Option) (*kms.GenerateMacOutput, error) {
+func (m *MockKMSAPI) GenerateMacWithContext(arg0 aws.Context, arg1 *kms.GenerateMacInput, arg2 ...request.Option) (*kms.GenerateMacOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1305,7 +1306,7 @@ func (mr *MockKMSAPIMockRecorder) GenerateRandomRequest(arg0 any) *gomock.Call {
 }
 
 // GenerateRandomWithContext mocks base method.
-func (m *MockKMSAPI) GenerateRandomWithContext(arg0 context.Context, arg1 *kms.GenerateRandomInput, arg2 ...request.Option) (*kms.GenerateRandomOutput, error) {
+func (m *MockKMSAPI) GenerateRandomWithContext(arg0 aws.Context, arg1 *kms.GenerateRandomInput, arg2 ...request.Option) (*kms.GenerateRandomOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1355,7 +1356,7 @@ func (mr *MockKMSAPIMockRecorder) GetKeyPolicyRequest(arg0 any) *gomock.Call {
 }
 
 // GetKeyPolicyWithContext mocks base method.
-func (m *MockKMSAPI) GetKeyPolicyWithContext(arg0 context.Context, arg1 *kms.GetKeyPolicyInput, arg2 ...request.Option) (*kms.GetKeyPolicyOutput, error) {
+func (m *MockKMSAPI) GetKeyPolicyWithContext(arg0 aws.Context, arg1 *kms.GetKeyPolicyInput, arg2 ...request.Option) (*kms.GetKeyPolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1405,7 +1406,7 @@ func (mr *MockKMSAPIMockRecorder) GetKeyRotationStatusRequest(arg0 any) *gomock.
 }
 
 // GetKeyRotationStatusWithContext mocks base method.
-func (m *MockKMSAPI) GetKeyRotationStatusWithContext(arg0 context.Context, arg1 *kms.GetKeyRotationStatusInput, arg2 ...request.Option) (*kms.GetKeyRotationStatusOutput, error) {
+func (m *MockKMSAPI) GetKeyRotationStatusWithContext(arg0 aws.Context, arg1 *kms.GetKeyRotationStatusInput, arg2 ...request.Option) (*kms.GetKeyRotationStatusOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1455,7 +1456,7 @@ func (mr *MockKMSAPIMockRecorder) GetParametersForImportRequest(arg0 any) *gomoc
 }
 
 // GetParametersForImportWithContext mocks base method.
-func (m *MockKMSAPI) GetParametersForImportWithContext(arg0 context.Context, arg1 *kms.GetParametersForImportInput, arg2 ...request.Option) (*kms.GetParametersForImportOutput, error) {
+func (m *MockKMSAPI) GetParametersForImportWithContext(arg0 aws.Context, arg1 *kms.GetParametersForImportInput, arg2 ...request.Option) (*kms.GetParametersForImportOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1505,7 +1506,7 @@ func (mr *MockKMSAPIMockRecorder) GetPublicKeyRequest(arg0 any) *gomock.Call {
 }
 
 // GetPublicKeyWithContext mocks base method.
-func (m *MockKMSAPI) GetPublicKeyWithContext(arg0 context.Context, arg1 *kms.GetPublicKeyInput, arg2 ...request.Option) (*kms.GetPublicKeyOutput, error) {
+func (m *MockKMSAPI) GetPublicKeyWithContext(arg0 aws.Context, arg1 *kms.GetPublicKeyInput, arg2 ...request.Option) (*kms.GetPublicKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1555,7 +1556,7 @@ func (mr *MockKMSAPIMockRecorder) ImportKeyMaterialRequest(arg0 any) *gomock.Cal
 }
 
 // ImportKeyMaterialWithContext mocks base method.
-func (m *MockKMSAPI) ImportKeyMaterialWithContext(arg0 context.Context, arg1 *kms.ImportKeyMaterialInput, arg2 ...request.Option) (*kms.ImportKeyMaterialOutput, error) {
+func (m *MockKMSAPI) ImportKeyMaterialWithContext(arg0 aws.Context, arg1 *kms.ImportKeyMaterialInput, arg2 ...request.Option) (*kms.ImportKeyMaterialOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1604,7 +1605,7 @@ func (mr *MockKMSAPIMockRecorder) ListAliasesPages(arg0, arg1 any) *gomock.Call 
 }
 
 // ListAliasesPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListAliasesPagesWithContext(arg0 context.Context, arg1 *kms.ListAliasesInput, arg2 func(*kms.ListAliasesOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListAliasesPagesWithContext(arg0 aws.Context, arg1 *kms.ListAliasesInput, arg2 func(*kms.ListAliasesOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1638,7 +1639,7 @@ func (mr *MockKMSAPIMockRecorder) ListAliasesRequest(arg0 any) *gomock.Call {
 }
 
 // ListAliasesWithContext mocks base method.
-func (m *MockKMSAPI) ListAliasesWithContext(arg0 context.Context, arg1 *kms.ListAliasesInput, arg2 ...request.Option) (*kms.ListAliasesOutput, error) {
+func (m *MockKMSAPI) ListAliasesWithContext(arg0 aws.Context, arg1 *kms.ListAliasesInput, arg2 ...request.Option) (*kms.ListAliasesOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1687,7 +1688,7 @@ func (mr *MockKMSAPIMockRecorder) ListGrantsPages(arg0, arg1 any) *gomock.Call {
 }
 
 // ListGrantsPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListGrantsPagesWithContext(arg0 context.Context, arg1 *kms.ListGrantsInput, arg2 func(*kms.ListGrantsResponse, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListGrantsPagesWithContext(arg0 aws.Context, arg1 *kms.ListGrantsInput, arg2 func(*kms.ListGrantsResponse, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1721,7 +1722,7 @@ func (mr *MockKMSAPIMockRecorder) ListGrantsRequest(arg0 any) *gomock.Call {
 }
 
 // ListGrantsWithContext mocks base method.
-func (m *MockKMSAPI) ListGrantsWithContext(arg0 context.Context, arg1 *kms.ListGrantsInput, arg2 ...request.Option) (*kms.ListGrantsResponse, error) {
+func (m *MockKMSAPI) ListGrantsWithContext(arg0 aws.Context, arg1 *kms.ListGrantsInput, arg2 ...request.Option) (*kms.ListGrantsResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1770,7 +1771,7 @@ func (mr *MockKMSAPIMockRecorder) ListKeyPoliciesPages(arg0, arg1 any) *gomock.C
 }
 
 // ListKeyPoliciesPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListKeyPoliciesPagesWithContext(arg0 context.Context, arg1 *kms.ListKeyPoliciesInput, arg2 func(*kms.ListKeyPoliciesOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListKeyPoliciesPagesWithContext(arg0 aws.Context, arg1 *kms.ListKeyPoliciesInput, arg2 func(*kms.ListKeyPoliciesOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1804,7 +1805,7 @@ func (mr *MockKMSAPIMockRecorder) ListKeyPoliciesRequest(arg0 any) *gomock.Call 
 }
 
 // ListKeyPoliciesWithContext mocks base method.
-func (m *MockKMSAPI) ListKeyPoliciesWithContext(arg0 context.Context, arg1 *kms.ListKeyPoliciesInput, arg2 ...request.Option) (*kms.ListKeyPoliciesOutput, error) {
+func (m *MockKMSAPI) ListKeyPoliciesWithContext(arg0 aws.Context, arg1 *kms.ListKeyPoliciesInput, arg2 ...request.Option) (*kms.ListKeyPoliciesOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1853,7 +1854,7 @@ func (mr *MockKMSAPIMockRecorder) ListKeyRotationsPages(arg0, arg1 any) *gomock.
 }
 
 // ListKeyRotationsPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListKeyRotationsPagesWithContext(arg0 context.Context, arg1 *kms.ListKeyRotationsInput, arg2 func(*kms.ListKeyRotationsOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListKeyRotationsPagesWithContext(arg0 aws.Context, arg1 *kms.ListKeyRotationsInput, arg2 func(*kms.ListKeyRotationsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1887,7 +1888,7 @@ func (mr *MockKMSAPIMockRecorder) ListKeyRotationsRequest(arg0 any) *gomock.Call
 }
 
 // ListKeyRotationsWithContext mocks base method.
-func (m *MockKMSAPI) ListKeyRotationsWithContext(arg0 context.Context, arg1 *kms.ListKeyRotationsInput, arg2 ...request.Option) (*kms.ListKeyRotationsOutput, error) {
+func (m *MockKMSAPI) ListKeyRotationsWithContext(arg0 aws.Context, arg1 *kms.ListKeyRotationsInput, arg2 ...request.Option) (*kms.ListKeyRotationsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -1936,7 +1937,7 @@ func (mr *MockKMSAPIMockRecorder) ListKeysPages(arg0, arg1 any) *gomock.Call {
 }
 
 // ListKeysPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListKeysPagesWithContext(arg0 context.Context, arg1 *kms.ListKeysInput, arg2 func(*kms.ListKeysOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListKeysPagesWithContext(arg0 aws.Context, arg1 *kms.ListKeysInput, arg2 func(*kms.ListKeysOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -1970,7 +1971,7 @@ func (mr *MockKMSAPIMockRecorder) ListKeysRequest(arg0 any) *gomock.Call {
 }
 
 // ListKeysWithContext mocks base method.
-func (m *MockKMSAPI) ListKeysWithContext(arg0 context.Context, arg1 *kms.ListKeysInput, arg2 ...request.Option) (*kms.ListKeysOutput, error) {
+func (m *MockKMSAPI) ListKeysWithContext(arg0 aws.Context, arg1 *kms.ListKeysInput, arg2 ...request.Option) (*kms.ListKeysOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2019,7 +2020,7 @@ func (mr *MockKMSAPIMockRecorder) ListResourceTagsPages(arg0, arg1 any) *gomock.
 }
 
 // ListResourceTagsPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListResourceTagsPagesWithContext(arg0 context.Context, arg1 *kms.ListResourceTagsInput, arg2 func(*kms.ListResourceTagsOutput, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListResourceTagsPagesWithContext(arg0 aws.Context, arg1 *kms.ListResourceTagsInput, arg2 func(*kms.ListResourceTagsOutput, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -2053,7 +2054,7 @@ func (mr *MockKMSAPIMockRecorder) ListResourceTagsRequest(arg0 any) *gomock.Call
 }
 
 // ListResourceTagsWithContext mocks base method.
-func (m *MockKMSAPI) ListResourceTagsWithContext(arg0 context.Context, arg1 *kms.ListResourceTagsInput, arg2 ...request.Option) (*kms.ListResourceTagsOutput, error) {
+func (m *MockKMSAPI) ListResourceTagsWithContext(arg0 aws.Context, arg1 *kms.ListResourceTagsInput, arg2 ...request.Option) (*kms.ListResourceTagsOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2102,7 +2103,7 @@ func (mr *MockKMSAPIMockRecorder) ListRetirableGrantsPages(arg0, arg1 any) *gomo
 }
 
 // ListRetirableGrantsPagesWithContext mocks base method.
-func (m *MockKMSAPI) ListRetirableGrantsPagesWithContext(arg0 context.Context, arg1 *kms.ListRetirableGrantsInput, arg2 func(*kms.ListGrantsResponse, bool) bool, arg3 ...request.Option) error {
+func (m *MockKMSAPI) ListRetirableGrantsPagesWithContext(arg0 aws.Context, arg1 *kms.ListRetirableGrantsInput, arg2 func(*kms.ListGrantsResponse, bool) bool, arg3 ...request.Option) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2}
 	for _, a := range arg3 {
@@ -2136,7 +2137,7 @@ func (mr *MockKMSAPIMockRecorder) ListRetirableGrantsRequest(arg0 any) *gomock.C
 }
 
 // ListRetirableGrantsWithContext mocks base method.
-func (m *MockKMSAPI) ListRetirableGrantsWithContext(arg0 context.Context, arg1 *kms.ListRetirableGrantsInput, arg2 ...request.Option) (*kms.ListGrantsResponse, error) {
+func (m *MockKMSAPI) ListRetirableGrantsWithContext(arg0 aws.Context, arg1 *kms.ListRetirableGrantsInput, arg2 ...request.Option) (*kms.ListGrantsResponse, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2186,7 +2187,7 @@ func (mr *MockKMSAPIMockRecorder) PutKeyPolicyRequest(arg0 any) *gomock.Call {
 }
 
 // PutKeyPolicyWithContext mocks base method.
-func (m *MockKMSAPI) PutKeyPolicyWithContext(arg0 context.Context, arg1 *kms.PutKeyPolicyInput, arg2 ...request.Option) (*kms.PutKeyPolicyOutput, error) {
+func (m *MockKMSAPI) PutKeyPolicyWithContext(arg0 aws.Context, arg1 *kms.PutKeyPolicyInput, arg2 ...request.Option) (*kms.PutKeyPolicyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2236,7 +2237,7 @@ func (mr *MockKMSAPIMockRecorder) ReEncryptRequest(arg0 any) *gomock.Call {
 }
 
 // ReEncryptWithContext mocks base method.
-func (m *MockKMSAPI) ReEncryptWithContext(arg0 context.Context, arg1 *kms.ReEncryptInput, arg2 ...request.Option) (*kms.ReEncryptOutput, error) {
+func (m *MockKMSAPI) ReEncryptWithContext(arg0 aws.Context, arg1 *kms.ReEncryptInput, arg2 ...request.Option) (*kms.ReEncryptOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2286,7 +2287,7 @@ func (mr *MockKMSAPIMockRecorder) ReplicateKeyRequest(arg0 any) *gomock.Call {
 }
 
 // ReplicateKeyWithContext mocks base method.
-func (m *MockKMSAPI) ReplicateKeyWithContext(arg0 context.Context, arg1 *kms.ReplicateKeyInput, arg2 ...request.Option) (*kms.ReplicateKeyOutput, error) {
+func (m *MockKMSAPI) ReplicateKeyWithContext(arg0 aws.Context, arg1 *kms.ReplicateKeyInput, arg2 ...request.Option) (*kms.ReplicateKeyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2336,7 +2337,7 @@ func (mr *MockKMSAPIMockRecorder) RetireGrantRequest(arg0 any) *gomock.Call {
 }
 
 // RetireGrantWithContext mocks base method.
-func (m *MockKMSAPI) RetireGrantWithContext(arg0 context.Context, arg1 *kms.RetireGrantInput, arg2 ...request.Option) (*kms.RetireGrantOutput, error) {
+func (m *MockKMSAPI) RetireGrantWithContext(arg0 aws.Context, arg1 *kms.RetireGrantInput, arg2 ...request.Option) (*kms.RetireGrantOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2386,7 +2387,7 @@ func (mr *MockKMSAPIMockRecorder) RevokeGrantRequest(arg0 any) *gomock.Call {
 }
 
 // RevokeGrantWithContext mocks base method.
-func (m *MockKMSAPI) RevokeGrantWithContext(arg0 context.Context, arg1 *kms.RevokeGrantInput, arg2 ...request.Option) (*kms.RevokeGrantOutput, error) {
+func (m *MockKMSAPI) RevokeGrantWithContext(arg0 aws.Context, arg1 *kms.RevokeGrantInput, arg2 ...request.Option) (*kms.RevokeGrantOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2436,7 +2437,7 @@ func (mr *MockKMSAPIMockRecorder) RotateKeyOnDemandRequest(arg0 any) *gomock.Cal
 }
 
 // RotateKeyOnDemandWithContext mocks base method.
-func (m *MockKMSAPI) RotateKeyOnDemandWithContext(arg0 context.Context, arg1 *kms.RotateKeyOnDemandInput, arg2 ...request.Option) (*kms.RotateKeyOnDemandOutput, error) {
+func (m *MockKMSAPI) RotateKeyOnDemandWithContext(arg0 aws.Context, arg1 *kms.RotateKeyOnDemandInput, arg2 ...request.Option) (*kms.RotateKeyOnDemandOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2486,7 +2487,7 @@ func (mr *MockKMSAPIMockRecorder) ScheduleKeyDeletionRequest(arg0 any) *gomock.C
 }
 
 // ScheduleKeyDeletionWithContext mocks base method.
-func (m *MockKMSAPI) ScheduleKeyDeletionWithContext(arg0 context.Context, arg1 *kms.ScheduleKeyDeletionInput, arg2 ...request.Option) (*kms.ScheduleKeyDeletionOutput, error) {
+func (m *MockKMSAPI) ScheduleKeyDeletionWithContext(arg0 aws.Context, arg1 *kms.ScheduleKeyDeletionInput, arg2 ...request.Option) (*kms.ScheduleKeyDeletionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2536,7 +2537,7 @@ func (mr *MockKMSAPIMockRecorder) SignRequest(arg0 any) *gomock.Call {
 }
 
 // SignWithContext mocks base method.
-func (m *MockKMSAPI) SignWithContext(arg0 context.Context, arg1 *kms.SignInput, arg2 ...request.Option) (*kms.SignOutput, error) {
+func (m *MockKMSAPI) SignWithContext(arg0 aws.Context, arg1 *kms.SignInput, arg2 ...request.Option) (*kms.SignOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2586,7 +2587,7 @@ func (mr *MockKMSAPIMockRecorder) TagResourceRequest(arg0 any) *gomock.Call {
 }
 
 // TagResourceWithContext mocks base method.
-func (m *MockKMSAPI) TagResourceWithContext(arg0 context.Context, arg1 *kms.TagResourceInput, arg2 ...request.Option) (*kms.TagResourceOutput, error) {
+func (m *MockKMSAPI) TagResourceWithContext(arg0 aws.Context, arg1 *kms.TagResourceInput, arg2 ...request.Option) (*kms.TagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2636,7 +2637,7 @@ func (mr *MockKMSAPIMockRecorder) UntagResourceRequest(arg0 any) *gomock.Call {
 }
 
 // UntagResourceWithContext mocks base method.
-func (m *MockKMSAPI) UntagResourceWithContext(arg0 context.Context, arg1 *kms.UntagResourceInput, arg2 ...request.Option) (*kms.UntagResourceOutput, error) {
+func (m *MockKMSAPI) UntagResourceWithContext(arg0 aws.Context, arg1 *kms.UntagResourceInput, arg2 ...request.Option) (*kms.UntagResourceOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2686,7 +2687,7 @@ func (mr *MockKMSAPIMockRecorder) UpdateAliasRequest(arg0 any) *gomock.Call {
 }
 
 // UpdateAliasWithContext mocks base method.
-func (m *MockKMSAPI) UpdateAliasWithContext(arg0 context.Context, arg1 *kms.UpdateAliasInput, arg2 ...request.Option) (*kms.UpdateAliasOutput, error) {
+func (m *MockKMSAPI) UpdateAliasWithContext(arg0 aws.Context, arg1 *kms.UpdateAliasInput, arg2 ...request.Option) (*kms.UpdateAliasOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2736,7 +2737,7 @@ func (mr *MockKMSAPIMockRecorder) UpdateCustomKeyStoreRequest(arg0 any) *gomock.
 }
 
 // UpdateCustomKeyStoreWithContext mocks base method.
-func (m *MockKMSAPI) UpdateCustomKeyStoreWithContext(arg0 context.Context, arg1 *kms.UpdateCustomKeyStoreInput, arg2 ...request.Option) (*kms.UpdateCustomKeyStoreOutput, error) {
+func (m *MockKMSAPI) UpdateCustomKeyStoreWithContext(arg0 aws.Context, arg1 *kms.UpdateCustomKeyStoreInput, arg2 ...request.Option) (*kms.UpdateCustomKeyStoreOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2786,7 +2787,7 @@ func (mr *MockKMSAPIMockRecorder) UpdateKeyDescriptionRequest(arg0 any) *gomock.
 }
 
 // UpdateKeyDescriptionWithContext mocks base method.
-func (m *MockKMSAPI) UpdateKeyDescriptionWithContext(arg0 context.Context, arg1 *kms.UpdateKeyDescriptionInput, arg2 ...request.Option) (*kms.UpdateKeyDescriptionOutput, error) {
+func (m *MockKMSAPI) UpdateKeyDescriptionWithContext(arg0 aws.Context, arg1 *kms.UpdateKeyDescriptionInput, arg2 ...request.Option) (*kms.UpdateKeyDescriptionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2836,7 +2837,7 @@ func (mr *MockKMSAPIMockRecorder) UpdatePrimaryRegionRequest(arg0 any) *gomock.C
 }
 
 // UpdatePrimaryRegionWithContext mocks base method.
-func (m *MockKMSAPI) UpdatePrimaryRegionWithContext(arg0 context.Context, arg1 *kms.UpdatePrimaryRegionInput, arg2 ...request.Option) (*kms.UpdatePrimaryRegionOutput, error) {
+func (m *MockKMSAPI) UpdatePrimaryRegionWithContext(arg0 aws.Context, arg1 *kms.UpdatePrimaryRegionInput, arg2 ...request.Option) (*kms.UpdatePrimaryRegionOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2901,7 +2902,7 @@ func (mr *MockKMSAPIMockRecorder) VerifyMacRequest(arg0 any) *gomock.Call {
 }
 
 // VerifyMacWithContext mocks base method.
-func (m *MockKMSAPI) VerifyMacWithContext(arg0 context.Context, arg1 *kms.VerifyMacInput, arg2 ...request.Option) (*kms.VerifyMacOutput, error) {
+func (m *MockKMSAPI) VerifyMacWithContext(arg0 aws.Context, arg1 *kms.VerifyMacInput, arg2 ...request.Option) (*kms.VerifyMacOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {
@@ -2936,7 +2937,7 @@ func (mr *MockKMSAPIMockRecorder) VerifyRequest(arg0 any) *gomock.Call {
 }
 
 // VerifyWithContext mocks base method.
-func (m *MockKMSAPI) VerifyWithContext(arg0 context.Context, arg1 *kms.VerifyInput, arg2 ...request.Option) (*kms.VerifyOutput, error) {
+func (m *MockKMSAPI) VerifyWithContext(arg0 aws.Context, arg1 *kms.VerifyInput, arg2 ...request.Option) (*kms.VerifyOutput, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1}
 	for _, a := range arg2 {


### PR DESCRIPTION
Closes #102.

## Summary by Sourcery

Regenerate AWS SDK mocks and update dependencies

Enhancements:
- Update DynamoDB and KMS mock implementations to use aws.Context instead of context.Context and add an isgomock marker field

Build:
- Bump Go version from 1.22 to 1.23 and toolchain to go1.24.2
- Upgrade go.uber.org/mock dependency to v0.5.2

Tests:
- Regenerate mocks with mockgen v0.5.2