### PR TITLE
Cobra's cmd.Print* can be stderr

### DIFF
--- a/internal/command/delete.go
+++ b/internal/command/delete.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"io"
+
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func deleteImpl(_ *cobra.Command, args []string, driver *internal.Driver) error {
+func deleteImpl(_ *cobra.Command, args []string, driver *internal.Driver, _ io.Writer) error {
 	return driver.DeleteSecrets(args[0], version, table) //nolint:wrapcheck
 }
 

--- a/internal/command/delete_test.go
+++ b/internal/command/delete_test.go
@@ -53,7 +53,7 @@ func TestDeleteCommand(t *testing.T) {
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
 
 	args := []string{name}
-	if err := deleteImpl(nil, args, driver); err != nil {
+	if err := deleteImpl(nil, args, driver, nil); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %v\n", nil, err)
 	}
 }

--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/kgaughan/gcredstash/internal"
@@ -14,7 +15,7 @@ var (
 	noErr bool
 )
 
-func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
+func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
 	context, err := internal.ParseContext(args[1:])
 	if err != nil {
 		return err //nolint:wrapcheck
@@ -41,7 +42,7 @@ func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 		if err != nil {
 			return fmt.Errorf("can't marshal credential: %w", err)
 		}
-		cmd.Print(string(result))
+		fmt.Fprint(out, string(result))
 	} else {
 		value, err := driver.GetSecret(credential, version, table, context)
 		if err != nil {
@@ -51,9 +52,9 @@ func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 			return err //nolint:wrapcheck
 		}
 		if noNL {
-			cmd.Print(value)
+			fmt.Fprint(out, value)
 		} else {
-			cmd.Println(value)
+			fmt.Fprintln(out, value)
 		}
 	}
 	return nil

--- a/internal/command/get_test.go
+++ b/internal/command/get_test.go
@@ -56,7 +56,7 @@ func TestGetCommand(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand()
 
 	args := []string{name}
-	if err := getImpl(cmd, args, driver); err != nil {
+	if err := getImpl(cmd, args, driver, out); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 
@@ -118,7 +118,7 @@ func TestGetCommandWithWildcard(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand()
 
 	args := []string{"test.*"}
-	if err := getImpl(cmd, args, driver); err != nil {
+	if err := getImpl(cmd, args, driver, out); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 
@@ -158,10 +158,10 @@ func TestGetCommandWithoutItem(t *testing.T) {
 	}, nil)
 
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
-	cmd, _ := testutils.NewDummyCommand()
+	cmd, out := testutils.NewDummyCommand()
 
 	args := []string{name}
-	err := getImpl(cmd, args, driver)
+	err := getImpl(cmd, args, driver, out)
 	if err == nil {
 		t.Errorf("expected error does not happen")
 	}

--- a/internal/command/getall.go
+++ b/internal/command/getall.go
@@ -2,12 +2,13 @@ package command
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func getAllImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
+func getAllImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
 	context, err := internal.ParseContext(args[0:])
 	if err != nil {
 		return err //nolint:wrapcheck
@@ -31,7 +32,7 @@ func getAllImpl(cmd *cobra.Command, args []string, driver *internal.Driver) erro
 		return fmt.Errorf("can't marshal credentials: %w", err)
 	}
 
-	cmd.Print(string(jsonString))
+	fmt.Fprint(out, string(jsonString))
 	return nil
 }
 

--- a/internal/command/getall_test.go
+++ b/internal/command/getall_test.go
@@ -63,7 +63,7 @@ func TestGetallCommand(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand()
 
 	args := []string{}
-	if err := getAllImpl(cmd, args, driver); err != nil {
+	if err := getAllImpl(cmd, args, driver, out); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 

--- a/internal/command/list.go
+++ b/internal/command/list.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io"
 	"sort"
 	"strconv"
 
@@ -9,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func listImpl(cmd *cobra.Command, _ []string, driver *internal.Driver) error {
+func listImpl(cmd *cobra.Command, _ []string, driver *internal.Driver, out io.Writer) error {
 	items, err := driver.ListSecrets(table)
 	if err != nil {
 		return err //nolint:wrapcheck
@@ -27,7 +28,7 @@ func listImpl(cmd *cobra.Command, _ []string, driver *internal.Driver) error {
 	}
 	sort.Strings(lines)
 	for _, line := range lines {
-		cmd.Println(line)
+		fmt.Fprintln(out, line)
 	}
 	return nil
 }

--- a/internal/command/list_test.go
+++ b/internal/command/list_test.go
@@ -43,7 +43,7 @@ func TestListCommand(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand()
 
 	args := []string{}
-	if err := listImpl(cmd, args, driver); err != nil {
+	if err := listImpl(cmd, args, driver, out); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %v\n", nil, err)
 	}
 

--- a/internal/command/make_driver.go
+++ b/internal/command/make_driver.go
@@ -3,9 +3,12 @@ package command
 import (
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
+
+	"io"
+	"os"
 )
 
-func wrapWithDriver(fn func(*cobra.Command, []string, *internal.Driver) error) func(*cobra.Command, []string) error {
+func wrapWithDriver(fn func(*cobra.Command, []string, *internal.Driver, io.Writer) error) func(*cobra.Command, []string) error {
 	driver, err := internal.NewDriver()
 	if err != nil {
 		return func(_ *cobra.Command, _ []string) error {
@@ -13,6 +16,6 @@ func wrapWithDriver(fn func(*cobra.Command, []string, *internal.Driver) error) f
 		}
 	}
 	return func(cmd *cobra.Command, args []string) error {
-		return fn(cmd, args, driver) //nolint:wrapcheck
+		return fn(cmd, args, driver, os.Stdout) //nolint:wrapcheck
 	}
 }

--- a/internal/command/put.go
+++ b/internal/command/put.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
@@ -12,7 +13,7 @@ var (
 	autoVersion bool
 )
 
-func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
+func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
 	context, err := internal.ParseContext(args[2:])
 	if err != nil {
 		return err //nolint:wrapcheck
@@ -38,7 +39,7 @@ func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 		return fmt.Errorf("can't store secret: %w", err)
 	}
 
-	cmd.Printf("%v has been stored\n", credential)
+	fmt.Fprintf(out, "%v has been stored\n", credential)
 	return nil
 }
 

--- a/internal/command/put_test.go
+++ b/internal/command/put_test.go
@@ -68,12 +68,12 @@ func TestPutCommand(t *testing.T) {
 	}).Return(nil, nil)
 
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
-	cmd, _ := testutils.NewDummyCommand()
+	cmd, out := testutils.NewDummyCommand()
 
 	autoVersion = true
 
 	args := []string{name, secret}
-	if err := putImpl(cmd, args, driver); err != nil {
+	if err := putImpl(cmd, args, driver, out); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 }

--- a/internal/command/setup.go
+++ b/internal/command/setup.go
@@ -1,11 +1,13 @@
 package command
 
 import (
+	"io"
+
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func setupImpl(_ *cobra.Command, _ []string, driver *internal.Driver) error {
+func setupImpl(_ *cobra.Command, _ []string, driver *internal.Driver, _ io.Writer) error {
 	return driver.CreateDdbTable(table) //nolint:wrapcheck
 }
 

--- a/internal/command/setup_test.go
+++ b/internal/command/setup_test.go
@@ -61,10 +61,10 @@ func TestSetupCommand(t *testing.T) {
 	}, nil)
 
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
-	cmd, _ := testutils.NewDummyCommand()
+	cmd, out := testutils.NewDummyCommand()
 
 	args := []string{}
-	if err := setupImpl(cmd, args, driver); err != nil {
+	if err := setupImpl(cmd, args, driver, out); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 }

--- a/internal/command/template.go
+++ b/internal/command/template.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"html/template"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -15,7 +16,7 @@ import (
 
 var inplace bool
 
-func templateImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
+func templateImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
 	tmplFile := args[0]
 
 	var content string
@@ -45,7 +46,7 @@ func templateImpl(cmd *cobra.Command, args []string, driver *internal.Driver) er
 		}
 	}
 
-	cmd.Print(buf.String())
+	fmt.Fprint(out, buf.String())
 	return nil
 }
 

--- a/internal/command/template_test.go
+++ b/internal/command/template_test.go
@@ -64,7 +64,7 @@ CMD_OUT={{sh "echo 100"}}`
 		cmd, out := testutils.NewDummyCommand()
 
 		args := []string{tmpfile.Name()}
-		if err := templateImpl(cmd, args, driver); err != nil {
+		if err := templateImpl(cmd, args, driver, out); err != nil {
 			t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 		}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,11 @@
 #    uv pip compile requirements.in
 babel==2.17.0
     # via mkdocs-material
-backrefs==5.8
+backrefs==5.9
     # via mkdocs-material
-bracex==2.5.post1
+bracex==2.6
     # via wcmatch
-certifi==2025.4.26
+certifi==2025.6.15
     # via requests
 charset-normalizer==3.4.2
     # via requests
@@ -22,7 +22,7 @@ jinja2==3.1.6
     # via
     #   mkdocs
     #   mkdocs-material
-markdown==3.8
+markdown==3.8.2
     # via
     #   mkdocs
     #   mkdocs-material
@@ -58,9 +58,9 @@ pathspec==0.12.1
     # via mkdocs
 platformdirs==4.3.8
     # via mkdocs-get-deps
-pygments==2.19.1
+pygments==2.19.2
     # via mkdocs-material
-pymdown-extensions==10.15
+pymdown-extensions==10.16
     # via mkdocs-material
 python-dateutil==2.9.0.post0
     # via ghp-import
@@ -72,13 +72,13 @@ pyyaml==6.0.2
     #   pyyaml-env-tag
 pyyaml-env-tag==1.1
     # via mkdocs
-requests==2.32.3
+requests==2.32.4
     # via mkdocs-material
 six==1.17.0
     # via python-dateutil
-urllib3==2.4.0
+urllib3==2.5.0
     # via requests
 watchdog==6.0.0
     # via mkdocs
-wcmatch==10.0
+wcmatch==10.1
     # via mkdocs-awesome-pages-plugin


### PR DESCRIPTION
This is definitely not the behaviour we want! It should always print to stdout!

Also, fix some issues flagged in the docs pipeline by Dependabot.