### PR TITLE
Lean on Cobra for the stdout io.Writer

### DIFF
--- a/internal/command/delete.go
+++ b/internal/command/delete.go
@@ -1,13 +1,11 @@
 package command
 
 import (
-	"io"
-
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func deleteImpl(cmd *cobra.Command, args []string, driver *internal.Driver, _ io.Writer) error {
+func deleteImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	return driver.DeleteSecrets(cmd.Context(), args[0], version, table) //nolint:wrapcheck
 }
 

--- a/internal/command/delete_test.go
+++ b/internal/command/delete_test.go
@@ -61,8 +61,8 @@ func TestDeleteCommand(t *testing.T) {
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
 
 	args := []string{name}
-	cmd, out := testutils.NewDummyCommand(ctx)
-	if err := deleteImpl(cmd, args, driver, out); err != nil {
+	cmd, _ := testutils.NewDummyCommand(ctx)
+	if err := deleteImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %v\n", nil, err)
 	}
 }

--- a/internal/command/get.go
+++ b/internal/command/get.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/kgaughan/gcredstash/internal"
@@ -15,8 +14,9 @@ var (
 	noErr bool
 )
 
-func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
+func getImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
 
 	encCtx, err := internal.ParseContext(args[1:])
 	if err != nil {

--- a/internal/command/get_test.go
+++ b/internal/command/get_test.go
@@ -64,7 +64,7 @@ func TestGetCommand(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand(ctx)
 
 	args := []string{name}
-	if err := getImpl(cmd, args, driver, out); err != nil {
+	if err := getImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 
@@ -136,7 +136,7 @@ func TestGetCommandWithWildcard(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand(ctx)
 
 	args := []string{"test.*"}
-	if err := getImpl(cmd, args, driver, out); err != nil {
+	if err := getImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 
@@ -181,10 +181,10 @@ func TestGetCommandWithoutItem(t *testing.T) {
 	}, nil)
 
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
-	cmd, out := testutils.NewDummyCommand(ctx)
+	cmd, _ := testutils.NewDummyCommand(ctx)
 
 	args := []string{name}
-	err := getImpl(cmd, args, driver, out)
+	err := getImpl(cmd, args, driver)
 	if err == nil {
 		t.Errorf("expected error does not happen")
 	}

--- a/internal/command/getall.go
+++ b/internal/command/getall.go
@@ -2,14 +2,14 @@ package command
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func getAllImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
+func getAllImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
 
 	encCtx, err := internal.ParseContext(args[0:])
 	if err != nil {

--- a/internal/command/getall_test.go
+++ b/internal/command/getall_test.go
@@ -74,7 +74,7 @@ func TestGetallCommand(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand(ctx)
 
 	args := []string{}
-	if err := getAllImpl(cmd, args, driver, out); err != nil {
+	if err := getAllImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 

--- a/internal/command/list.go
+++ b/internal/command/list.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io"
 	"sort"
 	"strconv"
 
@@ -10,8 +9,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func listImpl(cmd *cobra.Command, _ []string, driver *internal.Driver, out io.Writer) error {
+func listImpl(cmd *cobra.Command, _ []string, driver *internal.Driver) error {
 	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
 
 	items, err := driver.ListSecrets(ctx, table)
 	if err != nil {

--- a/internal/command/list_test.go
+++ b/internal/command/list_test.go
@@ -48,7 +48,7 @@ func TestListCommand(t *testing.T) {
 	cmd, out := testutils.NewDummyCommand(ctx)
 
 	args := []string{}
-	if err := listImpl(cmd, args, driver, out); err != nil {
+	if err := listImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %v\n", nil, err)
 	}
 

--- a/internal/command/make_driver.go
+++ b/internal/command/make_driver.go
@@ -1,19 +1,16 @@
 package command
 
 import (
-	"io"
-	"os"
-
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func wrapWithDriver(fn func(*cobra.Command, []string, *internal.Driver, io.Writer) error) func(*cobra.Command, []string) error {
+func wrapWithDriver(fn func(*cobra.Command, []string, *internal.Driver) error) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		driver, err := internal.NewDriver(cmd.Context())
 		if err != nil {
 			return err //nolint:wrapcheck
 		}
-		return fn(cmd, args, driver, os.Stdout) //nolint:wrapcheck
+		return fn(cmd, args, driver) //nolint:wrapcheck
 	}
 }

--- a/internal/command/put.go
+++ b/internal/command/put.go
@@ -2,7 +2,6 @@ package command
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
@@ -13,8 +12,9 @@ var (
 	autoVersion bool
 )
 
-func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
+func putImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
 
 	encCtx, err := internal.ParseContext(args[2:])
 	if err != nil {

--- a/internal/command/put_test.go
+++ b/internal/command/put_test.go
@@ -79,12 +79,12 @@ func TestPutCommand(t *testing.T) {
 	).Return(nil, nil)
 
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
-	cmd, out := testutils.NewDummyCommand(ctx)
+	cmd, _ := testutils.NewDummyCommand(ctx)
 
 	autoVersion = true
 
 	args := []string{name, secret}
-	if err := putImpl(cmd, args, driver, out); err != nil {
+	if err := putImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 }

--- a/internal/command/setup.go
+++ b/internal/command/setup.go
@@ -1,13 +1,11 @@
 package command
 
 import (
-	"io"
-
 	"github.com/kgaughan/gcredstash/internal"
 	"github.com/spf13/cobra"
 )
 
-func setupImpl(cmd *cobra.Command, _ []string, driver *internal.Driver, _ io.Writer) error {
+func setupImpl(cmd *cobra.Command, _ []string, driver *internal.Driver) error {
 	return driver.CreateDdbTable(cmd.Context(), table) //nolint:wrapcheck
 }
 

--- a/internal/command/setup_test.go
+++ b/internal/command/setup_test.go
@@ -70,10 +70,10 @@ func TestSetupCommand(t *testing.T) {
 	}, nil)
 
 	driver := &internal.Driver{Ddb: mddb, Kms: mkms}
-	cmd, out := testutils.NewDummyCommand(ctx)
+	cmd, _ := testutils.NewDummyCommand(ctx)
 
 	args := []string{}
-	if err := setupImpl(cmd, args, driver, out); err != nil {
+	if err := setupImpl(cmd, args, driver); err != nil {
 		t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 	}
 }

--- a/internal/command/template.go
+++ b/internal/command/template.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"html/template"
-	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -17,8 +16,9 @@ import (
 
 var inplace bool
 
-func templateImpl(cmd *cobra.Command, args []string, driver *internal.Driver, out io.Writer) error {
+func templateImpl(cmd *cobra.Command, args []string, driver *internal.Driver) error {
 	ctx := cmd.Context()
+	out := cmd.OutOrStdout()
 
 	tmplFile := args[0]
 

--- a/internal/command/template_test.go
+++ b/internal/command/template_test.go
@@ -72,7 +72,7 @@ CMD_OUT={{sh "echo 100"}}`
 		cmd, out := testutils.NewDummyCommand(ctx)
 
 		args := []string{tmpfile.Name()}
-		if err := templateImpl(cmd, args, driver, out); err != nil {
+		if err := templateImpl(cmd, args, driver); err != nil {
 			t.Errorf("\nexpected: %v\ngot: %q\n", nil, err)
 		}
 


### PR DESCRIPTION
## Summary by Sourcery

Streamline the CLI command implementations by removing explicit io.Writer parameters and leveraging Cobra’s built-in output methods for stdout handling

Enhancements:
- Remove io.Writer parameters from all command implementations and use cmd.OutOrStdout() for output
- Update wrapWithDriver to match the new command signature without passing os.Stdout
- Adjust tests to drop the writer argument and ignore the output from NewDummyCommand