### PR TITLE
Switch to golangci-lint v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.64.8
+        version: v2.3.0
         args: --issues-exit-code=0
         only-new-issues: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
         cache: true
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: v2.3.0
         args: --issues-exit-code=0

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,39 +1,47 @@
----
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-    # fast, autofix
-    - dupword
-    - godot
-    - gofumpt
-    - goimports
-    - whitespace
-
-    # fast, nofix
     - dupl
-    - gci
-    - ineffassign
-
-    # slow, nofix
+    - dupword
     - err113
     - errcheck
     - errname
     - errorlint
-    - gosimple
+    - godot
+    - gosec
     - govet
+    - ineffassign
     - nonamedreturns
     - revive
     - staticcheck
-    - typecheck
+    - tparallel
     - unconvert
     - unused
     - usetesting
+    - whitespace
     - wrapcheck
-
-    # Undecided
-    - tparallel
-    - gosec
-
-issues:
-  exclude-dirs:
-    - src/mockaws
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - src/mockaws
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofumpt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - src/mockaws
+      - third_party$
+      - builtin$
+      - examples$


### PR DESCRIPTION
## Summary by Sourcery

Switch to golangci-lint v2 by migrating the YAML configuration to the new format and bumping the CI lint action to v2.3.0

Enhancements:
- Upgrade golangci-lint configuration to v2 syntax, replacing disable-all with default:none, reorganizing enabled linters, and adding exclusions and presets

CI:
- Update GitHub Actions lint job to use golangci-lint v2.3.0