### PR TITLE
Sync workflows across from mercury

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,17 +17,32 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
+      - uses: dorny/paths-filter@v4.0.1
+        name: check for changes
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.*'
+
+      - if: steps.changes.outputs.src == 'true'
+        name: Set up Go
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
           cache: true
 
-      - name: Test
+      - if: steps.changes.outputs.src == 'true'
+        name: Run tests
         run: make tests
 
-      - name: Build
+      - if: steps.changes.outputs.src == 'true'
+        name: Build
         run: make build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
 
       - uses: actions/configure-pages@v6.0.0
         id: pages

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,17 +17,30 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v6
+      - uses: dorny/paths-filter@v4.0.1
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'cmd/**'
+              - 'internal/**'
+              - 'go.*'
+
+      - if: steps.changes.outputs.src == 'true'
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
-          cache: true
+          cache: false
 
-      - name: Lint
-        uses: golangci/golangci-lint-action@v8
+      - if: steps.changes.outputs.src == 'true'
+        name: Lint
+        uses: golangci/golangci-lint-action@v9.2.0
         with:
-          version: v2.3.0
+          version: v2.11.4
           args: --issues-exit-code=0
           only-new-issues: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v5
       - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist_credentials: true
 
       - name: Set up Go
         uses: actions/setup-go@v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,18 +20,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
           cache: true
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7.1.0
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ NAME:=gcredstash
 
 SOURCE:=$(wildcard internal/*.go internal/*/*.go cmd/*/*.go)
 
+.DEFAULT_GOAL:=build
+
 .PHONY: help
 help: ## Show this help message
 	@echo "Usage: make [target]"


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflows and Makefile defaults to align with the mercury configuration.

Build:
- Set the Makefile default target to build the project when running plain make.

CI:
- Upgrade GitHub Actions across build, lint, release, and docs workflows (checkout, setup-go, golangci-lint, goreleaser, configure-pages) to newer versions.
- Add path-based change detection so build and lint workflows only run Go-related steps when source files change.
- Disable Go module cache in the lint workflow and ensure actions run without persisting credentials.